### PR TITLE
Redesign UI: "Confident SaaS" overhaul (emerald brand, display type)

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -1,0 +1,84 @@
+# Scire — Design System ("Confident SaaS")
+
+The visual language for the whole app. Every page and component must conform.
+This is the single reference for the UI overhaul; when in doubt, match this.
+
+## The direction
+
+Confident, modern product SaaS — looks like a funded startup, not a template.
+We dropped the generic blue→indigo→purple gradient look entirely. No gradient
+blobs, no glassmorphism / "liquid glass", no dotted-grid backdrops, no Inter.
+
+- **Palette:** warm off-white canvas, rich near-black ink, a single confident
+  **emerald** brand color used deliberately (not everywhere).
+- **Type:** **Schibsted Grotesk** for display/headings (tight tracking, heavy
+  weights), **Hanken Grotesk** for body/UI. Numbers are tabular for data tables.
+- **Surfaces:** crisp tactile cards — hairline border + a real, low-spread
+  shadow. Generous padding. Sharp, intentional, never floaty.
+- **Motion:** restrained. One orchestrated page-load stagger on marketing
+  surfaces; quick (150–200ms) hover/press feedback in the app. Respect
+  `prefers-reduced-motion`. See the `web-motion-design` conventions.
+
+## Color tokens (defined in `globals.css`)
+
+Use semantic tokens — NEVER hardcode `blue-*`, `indigo-*`, `purple-*`, `gray-*`.
+
+| Token | Use |
+|---|---|
+| `bg-background` / `text-foreground` | page canvas / primary text |
+| `bg-card` / `text-card-foreground` | card & panel surfaces |
+| `bg-primary` / `text-primary-foreground` | primary CTAs (emerald) |
+| `bg-secondary` / `text-secondary-foreground` | secondary buttons/chips |
+| `bg-muted` / `text-muted-foreground` | subtle fills / secondary text |
+| `bg-accent` / `text-accent-foreground` | hover fills, soft emerald wash |
+| `border-border`, `bg-input`, `ring-ring` | hairlines, inputs, focus |
+| `bg-destructive` / red scale | errors / destructive |
+
+### Brand + status helper classes (added in `@theme`)
+
+- `bg-brand` / `text-brand` / `border-brand` — emerald brand (= primary).
+- `bg-brand-subtle` / `text-brand-strong` — soft emerald wash bg / deep emerald text.
+  Use for **active nav**, selected states, key highlights, brand chips.
+- Status colors (Tailwind built-ins are fine for these semantic roles):
+  - pending / waiting → `amber` (e.g. `bg-amber-50 text-amber-700 ring-amber-600/20`)
+  - approved / verified / positive → **brand** (emerald) tokens
+  - rejected / error / destructive → `bg-destructive` / `red`
+
+## Replacement rules for the overhaul (apply mechanically)
+
+- Active sidebar/nav item: `bg-blue-50 text-blue-700` → `bg-brand-subtle text-brand-strong`
+- Count badges / dots: `bg-blue-600 text-white` → `bg-brand text-primary-foreground`
+- Avatars: `bg-blue-100 text-blue-700` → `bg-brand-subtle text-brand-strong`
+- Links / inline emphasis: `text-blue-600 hover:underline` → `text-brand hover:text-brand-strong`
+- Focus rings: `ring-blue-500` → `ring-ring`
+- Icon accents: `text-blue-600` → `text-brand`
+- Any remaining `gray-*` → the matching neutral token (`text-muted-foreground`,
+  `border-border`, etc.).
+
+## Typography scale
+
+- Page title (h1): `font-display text-2xl/3xl font-semibold tracking-tight`
+- Section heading (h2): `font-display text-lg font-semibold tracking-tight`
+- Body: default (Hanken Grotesk), `text-sm`/`text-base`
+- Numeric / IDs / hours: `tabular-nums` (and `font-mono` for raw IDs/SHAs)
+- Marketing hero: `font-display text-5xl/7xl font-bold tracking-[-0.02em]`
+
+## Components
+
+- Use the shared `@/components/ui/*` primitives (Button, Card, Badge, Input,
+  Select, Dialog, Alert). They're already token-driven — don't re-style them
+  per page. If a page needs a variant, add it to the primitive, don't fork it.
+- **Cards:** `Card` is the tactile surface — border + shadow-sm. Group related
+  content in cards; don't float bare text on the canvas.
+- **Buttons:** `default` = emerald CTA, `outline` = secondary, `ghost` = tertiary.
+- **PageHeader pattern:** every app page opens with a title (font-display) +
+  one-line muted description, optional action button on the right.
+
+## Don'ts
+
+- ❌ gradient blobs, blurred color orbs, `animate-pulse` background decals
+- ❌ glassmorphism / heavy backdrop-blur as decoration
+- ❌ Inter, Roboto, Arial, Space Grotesk, system-ui as the brand face
+- ❌ purple/indigo/blue accents anywhere
+- ❌ rainbow of accent colors — emerald is the only brand hue; amber/red are
+  reserved for status semantics only

--- a/src/app/admin-login/admin-login-form.tsx
+++ b/src/app/admin-login/admin-login-form.tsx
@@ -185,7 +185,7 @@ export function AdminLoginForm() {
         <CardContent className="space-y-6">
           <div className="flex flex-col items-center gap-3 text-center">
             <BrandMark size={40} />
-            <h1 className="text-xl font-semibold tracking-tight text-foreground">Sign in</h1>
+            <h1 className="font-display text-xl font-semibold tracking-tight text-foreground">Sign in</h1>
           </div>
 
           {step === "credentials" ? (

--- a/src/app/admin/admins/page.tsx
+++ b/src/app/admin/admins/page.tsx
@@ -41,8 +41,8 @@ export default function AdminAdminsPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <KeyRound className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <KeyRound className="size-6 text-brand" aria-hidden="true" />
           Admins
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">The Scire platform administrators.</p>
@@ -78,7 +78,7 @@ export default function AdminAdminsPage() {
           <ul className="divide-y">
             {admins.map((a) => (
               <li key={a.id} className="flex items-center gap-3 px-4 py-3">
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 uppercase">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-sm font-semibold text-brand-strong uppercase">
                   {(a.first_name[0] ?? "") + (a.last_name[0] ?? "") || "?"}
                 </span>
                 <div className="min-w-0 flex-1">

--- a/src/app/admin/audit/page.tsx
+++ b/src/app/admin/audit/page.tsx
@@ -111,8 +111,8 @@ export default function AdminAuditPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <ScrollText className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <ScrollText className="size-6 text-brand" aria-hidden="true" />
           Audit log
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -44,7 +44,7 @@ export default function AdminDashboardPage() {
   return (
     <div className="space-y-8">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Dashboard</h1>
+        <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">Dashboard</h1>
         <p className="text-sm text-muted-foreground">Scire platform overview.</p>
       </header>
 
@@ -90,12 +90,12 @@ function StatGrid({ data, loading }: { data: AdminOverview | null; loading: bool
         return (
           <Card key={s.key} className="gap-2 py-5">
             <CardContent className="space-y-2">
-              <span className="flex size-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+              <span className="flex size-9 items-center justify-center rounded-lg bg-brand-subtle text-brand">
                 <Icon className="size-5" aria-hidden="true" />
               </span>
               <p
                 className={cn(
-                  "text-2xl font-semibold",
+                  "text-2xl font-semibold tabular-nums",
                   loading ? "text-muted-foreground" : "text-foreground",
                 )}
               >
@@ -124,10 +124,10 @@ function ServiceHealth({ status }: { status: AdminStatus | null }) {
   const OverallIcon = overall.icon;
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">Service health</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">Service health</h2>
       <Card>
         <CardHeader className="flex-row items-center justify-between gap-2">
-          <CardTitle className="text-base">Status</CardTitle>
+          <CardTitle className="font-display text-base tracking-tight">Status</CardTitle>
           <span className={cn("inline-flex items-center gap-1.5 text-sm font-medium", overall.tone)}>
             <OverallIcon className="size-4" aria-hidden="true" />
             {overall.label}
@@ -169,7 +169,7 @@ function RecentActivity({ data, loading }: { data: AdminOverview | null; loading
 
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">Recent activity</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">Recent activity</h2>
       <Card>
         <CardContent className="py-2">
           <ul className="divide-y">

--- a/src/app/admin/managers/page.tsx
+++ b/src/app/admin/managers/page.tsx
@@ -52,8 +52,8 @@ export default function AdminManagersPage() {
     <div className="space-y-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <ShieldCheck className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <ShieldCheck className="size-6 text-brand" aria-hidden="true" />
             Managers
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/admin/members/[id]/page.tsx
+++ b/src/app/admin/members/[id]/page.tsx
@@ -108,7 +108,7 @@ export default function AdminAccountDetailPage({
 
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
             {name}
             <AccountStatusChip status={account.status} />
           </h1>
@@ -146,7 +146,7 @@ export default function AdminAccountDetailPage({
       {/* Actions */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Actions</CardTitle>
+          <CardTitle className="font-display text-base tracking-tight">Actions</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-2">
           {account.status === "pending" ? (
@@ -350,7 +350,7 @@ function SessionsTab({ account }: { account: AdminAccountDetail }) {
                 <span
                   className={cn(
                     "inline-flex items-center rounded-full px-1.5 py-0.5 text-xs font-medium",
-                    s.role === "tutor" ? "bg-blue-50 text-blue-700" : "bg-purple-50 text-purple-700",
+                    s.role === "tutor" ? "bg-brand-subtle text-brand-strong" : "bg-slate-100 text-slate-600",
                   )}
                 >
                   {s.role === "tutor" ? "Tutoring" : "Learning"}
@@ -373,7 +373,7 @@ function HoursTab({ account }: { account: AdminAccountDetail }) {
     <div className="space-y-4">
       <Card className="gap-2 py-4">
         <CardContent className="space-y-1">
-          <p className="text-2xl font-semibold text-foreground">{formatHours(account.total_hours)} h</p>
+          <p className="font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground">{formatHours(account.total_hours)} h</p>
           <p className="text-sm text-muted-foreground">Total volunteer hours</p>
         </CardContent>
       </Card>
@@ -401,7 +401,7 @@ function HoursTab({ account }: { account: AdminAccountDetail }) {
                 </div>
                 <span
                   className={cn(
-                    "text-sm font-semibold",
+                    "text-sm font-semibold tabular-nums",
                     l.hours < 0 ? "text-red-600" : "text-green-600",
                   )}
                 >

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -49,8 +49,8 @@ export default function AdminMembersPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <Users className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <Users className="size-6 text-brand" aria-hidden="true" />
           Members
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/admin/orgs/[orgId]/page.tsx
+++ b/src/app/admin/orgs/[orgId]/page.tsx
@@ -111,8 +111,8 @@ export default function AdminOrgDetailPage({
 
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <Building2 className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <Building2 className="size-6 text-brand" aria-hidden="true" />
             {org.name}
             {archived ? (
               <span className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground ring-1 ring-inset ring-border">
@@ -246,12 +246,12 @@ function OverviewTab({ orgId }: { orgId: string }) {
         return (
           <Card key={s.key} className="gap-2 py-4">
             <CardContent className="space-y-1.5">
-              <span className="flex size-8 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+              <span className="flex size-8 items-center justify-center rounded-lg bg-brand-subtle text-brand">
                 <Icon className="size-4" aria-hidden="true" />
               </span>
               <p
                 className={cn(
-                  "text-xl font-semibold",
+                  "text-xl font-semibold tabular-nums",
                   loading ? "text-muted-foreground" : "text-foreground",
                 )}
               >
@@ -325,7 +325,7 @@ function SettingsTab({
       <Card>
         <CardContent className="space-y-4 py-5">
           <div>
-            <h3 className="text-sm font-semibold text-foreground">Details</h3>
+            <h3 className="font-display text-sm font-semibold tracking-tight text-foreground">Details</h3>
             <p className="text-sm text-muted-foreground">
               Rename the organization or change its slug.
             </p>
@@ -349,7 +349,7 @@ function SettingsTab({
       <Card>
         <CardContent className="space-y-3 py-5">
           <div>
-            <h3 className="text-sm font-semibold text-foreground">
+            <h3 className="font-display text-sm font-semibold tracking-tight text-foreground">
               {archived ? "Restore organization" : "Archive organization"}
             </h3>
             <p className="text-sm text-muted-foreground">

--- a/src/app/admin/orgs/page.tsx
+++ b/src/app/admin/orgs/page.tsx
@@ -59,8 +59,8 @@ export default function AdminOrgsPage() {
     <div className="space-y-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <Building2 className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <Building2 className="size-6 text-brand" aria-hidden="true" />
             Organizations
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/admin/security/page.tsx
+++ b/src/app/admin/security/page.tsx
@@ -125,8 +125,8 @@ export default function AdminSecurityPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <Lock className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <Lock className="size-6 text-brand" aria-hidden="true" />
           Security
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -136,8 +136,8 @@ export default function AdminSecurityPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
-            <ShieldCheck className="size-4 text-blue-600" aria-hidden="true" />
+          <CardTitle className="flex items-center gap-2 font-display text-base tracking-tight">
+            <ShieldCheck className="size-4 text-brand" aria-hidden="true" />
             Two-factor authentication
           </CardTitle>
         </CardHeader>
@@ -161,7 +161,7 @@ export default function AdminSecurityPage() {
                   width={180}
                   height={180}
                   unoptimized
-                  className="rounded-md border bg-white p-2"
+                  className="rounded-md border bg-card p-2"
                 />
                 <p className="text-center text-xs text-muted-foreground">
                   Can&apos;t scan? Enter this key manually:

--- a/src/app/admin/sessions/page.tsx
+++ b/src/app/admin/sessions/page.tsx
@@ -49,8 +49,8 @@ export default function AdminSessionsPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <CalendarRange className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <CalendarRange className="size-6 text-brand" aria-hidden="true" />
           Sessions
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/admin/template/page.tsx
+++ b/src/app/admin/template/page.tsx
@@ -118,8 +118,8 @@ export default function AdminTemplatePage() {
     <div className="space-y-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <LayoutTemplate className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <LayoutTemplate className="size-6 text-brand" aria-hidden="true" />
             Subject template
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/auth/accept-invite/page.tsx
+++ b/src/app/auth/accept-invite/page.tsx
@@ -100,7 +100,7 @@ export default function AcceptInvitePage() {
         <CardContent className="space-y-6">
           <div className="flex flex-col items-center gap-3 text-center">
             <BrandMark size={40} />
-            <h1 className="text-xl font-semibold tracking-tight text-foreground">
+            <h1 className="font-display text-xl font-semibold tracking-tight text-foreground">
               Set your password
             </h1>
             <p className="text-sm text-muted-foreground">

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -15,7 +15,7 @@ export default function ForgotPasswordPage() {
           Remembered it?{" "}
           <Link
             href="/auth/login"
-            className="font-medium text-blue-600 underline-offset-4 hover:underline"
+            className="font-medium text-brand underline-offset-4 hover:underline"
           >
             Log in
           </Link>

--- a/src/app/auth/login/manager/page.tsx
+++ b/src/app/auth/login/manager/page.tsx
@@ -18,7 +18,7 @@ export default function ManagerLoginPage() {
             Need a manager account?{" "}
             <Link
               href="/auth/register/manager"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Register as a manager
             </Link>
@@ -26,7 +26,7 @@ export default function ManagerLoginPage() {
           <p>
             <Link
               href="/auth/login"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Member sign in →
             </Link>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -16,7 +16,7 @@ export default function LoginPage() {
             New to Scire?{" "}
             <Link
               href="/auth/register"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Create an account
             </Link>
@@ -24,7 +24,7 @@ export default function LoginPage() {
           <p>
             <Link
               href="/auth/login/manager"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Manager sign in →
             </Link>

--- a/src/app/auth/register/manager/page.tsx
+++ b/src/app/auth/register/manager/page.tsx
@@ -19,7 +19,7 @@ export default function ManagerRegisterPage() {
             Already a manager?{" "}
             <Link
               href="/auth/login/manager"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Manager sign in
             </Link>
@@ -28,7 +28,7 @@ export default function ManagerRegisterPage() {
             Looking to get tutored or tutor?{" "}
             <Link
               href="/auth/register"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Create a member account
             </Link>

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -16,7 +16,7 @@ export default function RegisterPage() {
             Already have an account?{" "}
             <Link
               href="/auth/login"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Log in
             </Link>
@@ -25,7 +25,7 @@ export default function RegisterPage() {
             Are you a teacher or club exec?{" "}
             <Link
               href="/auth/register/manager"
-              className="font-medium text-blue-600 underline-offset-4 hover:underline"
+              className="font-medium text-brand underline-offset-4 hover:underline"
             >
               Register as a manager
             </Link>

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -21,7 +21,7 @@ export default async function VerifyEmailPage({
         email ? (
           <>
             We sent a confirmation link to{" "}
-            <span className="font-medium text-gray-900">{email}</span>.
+            <span className="font-medium text-foreground">{email}</span>.
           </>
         ) : (
           "We sent you a confirmation link."
@@ -32,14 +32,14 @@ export default async function VerifyEmailPage({
           Already have an account?{" "}
           <Link
             href="/auth/login"
-            className="font-medium text-blue-600 underline-offset-4 hover:underline"
+            className="font-medium text-brand underline-offset-4 hover:underline"
           >
             Log in
           </Link>{" "}
           or{" "}
           <Link
             href="/auth/forgot-password"
-            className="font-medium text-blue-600 underline-offset-4 hover:underline"
+            className="font-medium text-brand underline-offset-4 hover:underline"
           >
             reset your password
           </Link>
@@ -49,12 +49,12 @@ export default async function VerifyEmailPage({
     >
       <div className="space-y-5">
         <div className="flex justify-center">
-          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-blue-50 text-blue-600">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-brand-subtle text-brand">
             <MailCheck aria-hidden className="h-7 w-7" />
           </div>
         </div>
 
-        <p className="text-center text-sm leading-6 text-gray-600">
+        <p className="text-center text-sm leading-6 text-muted-foreground">
           {isManager ? (
             <>
               Click the link to confirm your email, then sign in. The Scire team

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,9 @@
 @import "tw-animate-css";
 
 @theme inline {
-  --font-sans: var(--font-inter);
+  --font-sans: var(--font-hanken), ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-schibsted), var(--font-hanken), ui-sans-serif, sans-serif;
+  --font-mono: ui-monospace, "SF Mono", "JetBrains Mono", monospace;
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -23,6 +25,13 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+
+  /* Brand accent layer — emerald. Use deliberately (active states, highlights). */
+  --color-brand: var(--brand);
+  --color-brand-foreground: var(--brand-foreground);
+  --color-brand-subtle: var(--brand-subtle);
+  --color-brand-strong: var(--brand-strong);
+
   --color-chart-1: var(--chart-1);
   --color-chart-2: var(--chart-2);
   --color-chart-3: var(--chart-3);
@@ -41,43 +50,75 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* Crisp, low-spread tactile shadows (ink-tinted, not pure black). */
+  --shadow-2xs: 0 1px 2px 0 oklch(0.22 0.03 160 / 0.04);
+  --shadow-xs: 0 1px 2px 0 oklch(0.22 0.03 160 / 0.05), 0 1px 1px -1px oklch(0.22 0.03 160 / 0.04);
+  --shadow-sm: 0 1px 3px 0 oklch(0.22 0.03 160 / 0.07), 0 1px 2px -1px oklch(0.22 0.03 160 / 0.05);
+  --shadow-md: 0 4px 12px -2px oklch(0.22 0.03 160 / 0.08), 0 2px 4px -2px oklch(0.22 0.03 160 / 0.05);
+  --shadow-lg: 0 12px 28px -6px oklch(0.22 0.03 160 / 0.12), 0 4px 8px -4px oklch(0.22 0.03 160 / 0.06);
+  --shadow-xl: 0 24px 48px -12px oklch(0.22 0.03 160 / 0.16);
 }
 
-/* Light-only theme (new-york, neutral base). No dark variant ships in v1. */
+/*
+ * "Confident SaaS" — warm off-white canvas, rich ink text, a single confident
+ * emerald brand hue. Light-only (no dark variant ships in v1). All chroma is
+ * intentional: neutrals carry a faint warm cast so the page never reads as cold
+ * default-gray, and emerald is the only saturated brand color.
+ */
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
+  --radius: 0.7rem;
+
+  --background: oklch(0.985 0.004 106);
+  --foreground: oklch(0.22 0.012 160);
+
   --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
+  --card-foreground: oklch(0.22 0.012 160);
   --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --popover-foreground: oklch(0.22 0.012 160);
+
+  /* Primary = emerald brand. */
+  --primary: oklch(0.56 0.114 159);
+  --primary-foreground: oklch(0.985 0.012 150);
+
+  --secondary: oklch(0.962 0.006 130);
+  --secondary-foreground: oklch(0.30 0.02 160);
+
+  --muted: oklch(0.965 0.005 120);
+  --muted-foreground: oklch(0.515 0.014 150);
+
+  --accent: oklch(0.955 0.028 160);
+  --accent-foreground: oklch(0.40 0.072 159);
+
+  --destructive: oklch(0.585 0.224 27.5);
+  --destructive-foreground: oklch(0.985 0.01 60);
+
+  --border: oklch(0.912 0.006 130);
+  --input: oklch(0.905 0.006 130);
+  --ring: oklch(0.56 0.114 159);
+
+  /* Brand accent layer. */
+  --brand: oklch(0.56 0.114 159);
+  --brand-foreground: oklch(0.985 0.012 150);
+  --brand-subtle: oklch(0.955 0.03 160);
+  --brand-strong: oklch(0.42 0.088 159);
+
+  /* Data viz — emerald-anchored, harmonized hues (no clashing primaries). */
+  --chart-1: oklch(0.56 0.114 159);
+  --chart-2: oklch(0.66 0.12 196);
+  --chart-3: oklch(0.70 0.13 85);
+  --chart-4: oklch(0.62 0.16 41);
+  --chart-5: oklch(0.55 0.13 300);
+
+  /* Sidebar — a hair warmer than the canvas so panels read as distinct. */
+  --sidebar: oklch(0.992 0.004 106);
+  --sidebar-foreground: oklch(0.22 0.012 160);
+  --sidebar-primary: oklch(0.56 0.114 159);
+  --sidebar-primary-foreground: oklch(0.985 0.012 150);
+  --sidebar-accent: oklch(0.955 0.028 160);
+  --sidebar-accent-foreground: oklch(0.40 0.072 159);
+  --sidebar-border: oklch(0.912 0.006 130);
+  --sidebar-ring: oklch(0.56 0.114 159);
 }
 
 @layer base {
@@ -86,6 +127,35 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-inter), system-ui, sans-serif;
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  /* Tabular figures for data-dense UI (tables, hours, counts). */
+  table,
+  .tabular-nums {
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+@layer utilities {
+  /* One restrained page-load reveal for marketing surfaces. */
+  @keyframes rise-in {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .animate-rise-in {
+    animation: rise-in 0.6s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .animate-rise-in {
+      animation: none;
+    }
   }
 }

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="32" height="32" rx="7" fill="#2563eb" />
-  <text x="16" y="22" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="700" fill="#ffffff" text-anchor="middle">S</text>
+  <rect width="32" height="32" rx="9" fill="#26885b" />
+  <text x="16" y="22" font-family="ui-sans-serif, system-ui, sans-serif" font-size="20" font-weight="800" letter-spacing="-0.5" fill="#ffffff" text-anchor="middle">S</text>
 </svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,25 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Hanken_Grotesk, Schibsted_Grotesk } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import SupabaseListener from "./supabase-listener";
 import { BRAND } from "@/lib/brand";
 
-const inter = Inter({
-  variable: "--font-inter",
+// Body / UI face — a clean geometric grotesque with excellent small-size
+// legibility and tabular figures for the data-dense panels.
+const hanken = Hanken_Grotesk({
+  variable: "--font-hanken",
   subsets: ["latin"],
+  display: "swap",
+});
+
+// Display face — confident, tightly-tracked headlines. Distinct from the body
+// so titles carry weight without shouting.
+const schibsted = Schibsted_Grotesk({
+  variable: "--font-schibsted",
+  subsets: ["latin"],
+  weight: ["500", "600", "700", "800", "900"],
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -31,7 +43,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} antialiased`}>
+      <body className={`${hanken.variable} ${schibsted.variable} antialiased`}>
         <Providers>
           <SupabaseListener />
           {children}

--- a/src/app/manager/(panel)/approvals/page.tsx
+++ b/src/app/manager/(panel)/approvals/page.tsx
@@ -45,7 +45,7 @@ export default function ManagerApprovalsPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Tutoring approvals</h1>
+        <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">Tutoring approvals</h1>
         <p className="text-sm text-muted-foreground">
           Decide who can tutor which subjects.
         </p>
@@ -115,7 +115,7 @@ function RequestsTab() {
     return (
       <Card className="py-10 text-center">
         <CardContent className="flex flex-col items-center gap-2">
-          <span className="flex size-11 items-center justify-center rounded-full bg-green-50 text-green-600">
+          <span className="flex size-11 items-center justify-center rounded-full bg-brand-subtle text-brand">
             <Inbox className="size-5" aria-hidden="true" />
           </span>
           <p className="text-sm text-muted-foreground">No pending approval requests.</p>
@@ -285,7 +285,7 @@ function BySubjectTab() {
               <div className="min-w-0 flex-1">
                 <Link
                   href={`/manager/members/${m.member_id}`}
-                  className="font-medium text-foreground hover:text-blue-700 hover:underline"
+                  className="font-medium text-foreground hover:text-brand-strong hover:underline"
                 >
                   {personName(m)}
                 </Link>

--- a/src/app/manager/(panel)/dashboard/page.tsx
+++ b/src/app/manager/(panel)/dashboard/page.tsx
@@ -62,8 +62,8 @@ export default function ManagerOverviewPage() {
 
   return (
     <div className="space-y-8">
-      <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Overview</h1>
+      <header className="space-y-1">
+        <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">Overview</h1>
         <p className="text-sm text-muted-foreground">{orgName}</p>
       </header>
 
@@ -110,14 +110,14 @@ function StatGrid({ data, loading }: { data: ManageOverview | null; loading: boo
         return (
           <Card key={s.key} className="gap-2 py-5">
             <CardContent className="space-y-2">
-              <span className="flex size-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+              <span className="flex size-9 items-center justify-center rounded-xl bg-brand-subtle text-brand">
                 <Icon className="size-5" aria-hidden="true" />
               </span>
               <p
                 className={
                   loading
-                    ? "text-2xl font-semibold text-muted-foreground"
-                    : "text-2xl font-semibold text-foreground"
+                    ? "font-display text-2xl font-semibold tabular-nums text-muted-foreground"
+                    : "font-display text-2xl font-semibold tabular-nums text-foreground"
                 }
               >
                 {value}
@@ -188,8 +188,8 @@ function NeedsAttention({
   if (loading && !data) {
     return (
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold text-foreground">Needs attention</h2>
-        <div className="h-24 animate-pulse rounded-lg border bg-muted/40" />
+        <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">Needs attention</h2>
+        <div className="h-24 animate-pulse rounded-xl border bg-muted/40" />
       </section>
     );
   }
@@ -201,11 +201,11 @@ function NeedsAttention({
 
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">Needs attention</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">Needs attention</h2>
       {groups.length === 0 ? (
         <Card className="py-8 text-center">
           <CardContent className="flex flex-col items-center gap-2">
-            <span className="flex size-10 items-center justify-center rounded-full bg-green-50 text-green-600">
+            <span className="flex size-10 items-center justify-center rounded-full bg-brand-subtle text-brand">
               <ClipboardCheck className="size-5" aria-hidden="true" />
             </span>
             <p className="text-sm text-muted-foreground">
@@ -220,7 +220,7 @@ function NeedsAttention({
               <CardContent className="space-y-3 py-5">
                 <div className="flex items-center justify-between">
                   <h3 className="text-sm font-semibold text-foreground">{g.title}</h3>
-                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-semibold text-white">
+                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-brand px-1.5 text-xs font-semibold tabular-nums text-white">
                     {items.length}
                   </span>
                 </div>
@@ -269,7 +269,7 @@ function RecentActivity({
 
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">Recent activity</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">Recent activity</h2>
       <Card>
         <CardContent className="py-2">
           <ul className="divide-y">

--- a/src/app/manager/(panel)/emails/page.tsx
+++ b/src/app/manager/(panel)/emails/page.tsx
@@ -50,8 +50,8 @@ export default function ManagerEmailsPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <Mail className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <Mail className="size-6 text-brand" aria-hidden="true" />
           Emails
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -213,13 +213,13 @@ function ComposeTab({ onSent }: { onSent: () => void }) {
                   key={s.value}
                   className={
                     "flex cursor-pointer items-start gap-2.5 rounded-lg border p-3 transition-colors " +
-                    (active ? "border-blue-400 bg-blue-50/60" : "hover:bg-accent/50")
+                    (active ? "border-brand/60 bg-brand-subtle/60" : "hover:bg-accent/50")
                   }
                 >
                   <input
                     type="radio"
                     name="audience"
-                    className="mt-0.5 size-4 accent-blue-600"
+                    className="mt-0.5 size-4 accent-[oklch(0.56_0.114_159)]"
                     checked={active}
                     onChange={() => setScope(s.value)}
                   />
@@ -366,7 +366,7 @@ function MemberMultiSelect({
       {selected.length > 0 ? (
         <p className="text-xs text-muted-foreground">
           {selected.length} selected ·{" "}
-          <button type="button" className="text-blue-600 hover:underline" onClick={() => onChange([])}>
+          <button type="button" className="text-brand hover:underline" onClick={() => onChange([])}>
             Clear
           </button>
         </p>
@@ -381,7 +381,7 @@ function MemberMultiSelect({
                 <label className="flex cursor-pointer items-center gap-2.5 px-3 py-2 hover:bg-accent/50">
                   <input
                     type="checkbox"
-                    className="size-4 accent-blue-600"
+                    className="size-4 accent-[oklch(0.56_0.114_159)]"
                     checked={selectedSet.has(m.id)}
                     onChange={() => toggle(m.id)}
                   />
@@ -496,7 +496,7 @@ function BatchDetail({ batchId, onBack }: { batchId: string; onBack: () => void 
         <>
           <Card>
             <CardHeader>
-              <CardTitle className="text-base">{detail.batch.subject}</CardTitle>
+              <CardTitle className="font-display text-base tracking-tight">{detail.batch.subject}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               <p className="text-xs text-muted-foreground">
@@ -514,7 +514,7 @@ function BatchDetail({ batchId, onBack }: { batchId: string; onBack: () => void 
 
           <Card>
             <CardHeader>
-              <CardTitle className="text-base">
+              <CardTitle className="font-display text-base tracking-tight">
                 Recipients
                 <span className="ml-2 text-sm font-normal text-muted-foreground">
                   ({detail.recipients.length})

--- a/src/app/manager/(panel)/help/page.tsx
+++ b/src/app/manager/(panel)/help/page.tsx
@@ -23,8 +23,8 @@ export default function ManagerHelpPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <LifeBuoy className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <LifeBuoy className="size-6 text-brand" aria-hidden="true" />
           Help requests
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">

--- a/src/app/manager/(panel)/hours/page.tsx
+++ b/src/app/manager/(panel)/hours/page.tsx
@@ -67,8 +67,8 @@ export default function ManagerHoursPage() {
     <div className="space-y-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <Clock className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <Clock className="size-6 text-brand" aria-hidden="true" />
             Volunteer hours
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -223,7 +223,7 @@ function LedgerTab({ reloadToken }: { reloadToken: number }) {
                         {" · "}
                         <Link
                           href={`/manager/sessions/${r.session_id}`}
-                          className="text-blue-600 hover:underline"
+                          className="text-brand hover:underline"
                         >
                           {r.subject_name ? r.subject_name : "session"}
                         </Link>
@@ -258,7 +258,7 @@ function KindChip({ kind }: { kind: "award" | "adjustment" }) {
         "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset " +
         (kind === "award"
           ? "bg-green-50 text-green-700 ring-green-600/20"
-          : "bg-blue-50 text-blue-700 ring-blue-600/20")
+          : "bg-brand-subtle text-brand-strong ring-brand/20")
       }
     >
       {kind === "award" ? "Award" : "Adjustment"}

--- a/src/app/manager/(panel)/managers/page.tsx
+++ b/src/app/manager/(panel)/managers/page.tsx
@@ -58,8 +58,8 @@ export default function ManagerManagersPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">Managers</h1>
-        <p className="text-sm text-muted-foreground">
+        <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">Managers</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
           Managers for {profile.org?.name ?? "your organization"}.
         </p>
       </header>
@@ -73,7 +73,7 @@ export default function ManagerManagersPage() {
 
       {/* Pending */}
       <section className="space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">Pending activation</h2>
+        <h2 className="font-display text-sm font-semibold tracking-tight text-foreground">Pending activation</h2>
         {loading && rows.length === 0 ? (
           <SkeletonList />
         ) : pending.length === 0 ? (
@@ -114,7 +114,7 @@ export default function ManagerManagersPage() {
 
       {/* Active (read-only) */}
       <section className="space-y-3">
-        <h2 className="text-sm font-semibold text-foreground">Active managers</h2>
+        <h2 className="font-display text-sm font-semibold tracking-tight text-foreground">Active managers</h2>
         {loading && rows.length === 0 ? (
           <SkeletonList />
         ) : active.length === 0 ? (
@@ -130,7 +130,7 @@ export default function ManagerManagersPage() {
                 key={m.id}
                 className="flex flex-wrap items-center gap-3 rounded-lg border bg-card px-4 py-3"
               >
-                <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-blue-700">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-brand-strong">
                   <ShieldCheck className="size-4" aria-hidden="true" />
                 </span>
                 <div className="min-w-0 flex-1">

--- a/src/app/manager/(panel)/members/[memberId]/page.tsx
+++ b/src/app/manager/(panel)/members/[memberId]/page.tsx
@@ -108,12 +108,12 @@ export default function ManagerMemberDetailPage({
       <Card>
         <CardContent className="flex flex-wrap items-start justify-between gap-4 py-6">
           <div className="flex items-start gap-4">
-            <span className="flex size-12 shrink-0 items-center justify-center rounded-full bg-blue-100 text-base font-semibold text-blue-700 uppercase">
+            <span className="flex size-12 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-base font-semibold text-brand-strong uppercase">
               {(member.first_name[0] ?? "") + (member.last_name[0] ?? "") || "?"}
             </span>
             <div className="space-y-1">
               <div className="flex flex-wrap items-center gap-2">
-                <h1 className="text-xl font-semibold tracking-tight text-foreground">{name}</h1>
+                <h1 className="font-display text-xl font-semibold tracking-tight text-foreground">{name}</h1>
                 <AccountStatusChip status={member.status} />
               </div>
               <p className="flex items-center gap-1.5 text-sm text-muted-foreground">

--- a/src/app/manager/(panel)/members/admissions/page.tsx
+++ b/src/app/manager/(panel)/members/admissions/page.tsx
@@ -75,11 +75,16 @@ export default function ManagerAdmissionsPage() {
             Members
           </Link>
         </Button>
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Admissions</h1>
-          <p className="text-sm text-muted-foreground">
-            Members awaiting admission, oldest first.
-          </p>
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-brand-subtle text-brand">
+            <UserCheck className="size-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">Admissions</h1>
+            <p className="text-sm text-muted-foreground">
+              Members awaiting admission, oldest first.
+            </p>
+          </div>
         </div>
       </header>
 
@@ -116,7 +121,7 @@ export default function ManagerAdmissionsPage() {
               <div className="min-w-0 flex-1">
                 <Link
                   href={`/manager/members/${m.id}`}
-                  className="font-medium text-foreground hover:text-blue-700 hover:underline"
+                  className="font-medium text-foreground hover:text-brand-strong hover:underline"
                 >
                   {personName(m)}
                 </Link>

--- a/src/app/manager/(panel)/members/page.tsx
+++ b/src/app/manager/(panel)/members/page.tsx
@@ -100,18 +100,23 @@ export default function ManagerMembersPage() {
   return (
     <div className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Members</h1>
-          <p className="text-sm text-muted-foreground">
-            Everyone in your organization.
-          </p>
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-brand-subtle text-brand">
+            <Users className="size-5" aria-hidden="true" />
+          </span>
+          <div>
+            <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">Members</h1>
+            <p className="text-sm text-muted-foreground">
+              Everyone in your organization.
+            </p>
+          </div>
         </div>
         <Button asChild variant="outline">
           <Link href="/manager/members/admissions">
             <UserPlus className="size-4" aria-hidden="true" />
             Admissions
             {counts.pending_admissions > 0 ? (
-              <span className="ml-1 inline-flex min-w-5 items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-semibold text-white">
+              <span className="ml-1 inline-flex min-w-5 items-center justify-center rounded-full bg-brand px-1.5 text-xs font-semibold text-white">
                 {counts.pending_admissions}
               </span>
             ) : null}
@@ -282,7 +287,7 @@ function MemberTableRow({
       <td className="px-4 py-3">
         <Link
           href={`/manager/members/${member.id}`}
-          className="font-medium text-foreground hover:text-blue-700 hover:underline"
+          className="font-medium text-foreground hover:text-brand-strong hover:underline"
         >
           {personName(member)}
         </Link>

--- a/src/app/manager/(panel)/sessions/[sessionId]/page.tsx
+++ b/src/app/manager/(panel)/sessions/[sessionId]/page.tsx
@@ -156,7 +156,7 @@ export default function ManagerSessionDetailPage({
 
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
             {subjectLabel(session.subject)}
           </h1>
           <div className="mt-1.5 flex items-center gap-2">
@@ -171,7 +171,7 @@ export default function ManagerSessionDetailPage({
       {/* --- Interventions --- */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Manager actions</CardTitle>
+          <CardTitle className="font-display text-base tracking-tight">Manager actions</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
           {canCancel || canReopen || canRequestChanges || canVerify ? (
@@ -236,7 +236,7 @@ export default function ManagerSessionDetailPage({
       {/* --- Record --- */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Record</CardTitle>
+          <CardTitle className="font-display text-base tracking-tight">Record</CardTitle>
         </CardHeader>
         <CardContent>
           <dl className="grid gap-x-6 gap-y-3 sm:grid-cols-2">
@@ -274,7 +274,7 @@ export default function ManagerSessionDetailPage({
                 href={session.recording_url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-brand hover:underline"
               >
                 <ExternalLink className="size-4" aria-hidden="true" />
                 Open recording
@@ -299,7 +299,7 @@ export default function ManagerSessionDetailPage({
       {/* --- Availability (read-only) --- */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Availability</CardTitle>
+          <CardTitle className="font-display text-base tracking-tight">Availability</CardTitle>
         </CardHeader>
         <CardContent>
           <AvailabilityView availability={session.availability} />
@@ -309,7 +309,7 @@ export default function ManagerSessionDetailPage({
       {/* --- Timeline --- */}
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-base">
+          <CardTitle className="flex items-center gap-2 font-display text-base tracking-tight">
             <History className="size-4 text-muted-foreground" aria-hidden="true" />
             Timeline
           </CardTitle>
@@ -377,7 +377,7 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div>
       <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
-      <dd className="text-sm text-foreground">{value}</dd>
+      <dd className="text-sm text-foreground tabular-nums">{value}</dd>
     </div>
   );
 }
@@ -395,7 +395,7 @@ function Timeline({ entries }: { entries: SessionTimelineEntry[] }) {
     <ol className="space-y-3">
       {entries.map((e) => (
         <li key={e.id} className="flex gap-3">
-          <span className="mt-1.5 size-2 shrink-0 rounded-full bg-blue-500" aria-hidden="true" />
+          <span className="mt-1.5 size-2 shrink-0 rounded-full bg-brand" aria-hidden="true" />
           <div className="min-w-0">
             <p className="text-sm font-medium text-foreground">{humanizeAction(e.action)}</p>
             <p className="text-xs text-muted-foreground">

--- a/src/app/manager/(panel)/sessions/page.tsx
+++ b/src/app/manager/(panel)/sessions/page.tsx
@@ -131,8 +131,8 @@ export default function ManagerSessionsPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <CalendarRange className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <CalendarRange className="size-6 text-brand" aria-hidden="true" />
           Sessions
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -151,7 +151,7 @@ export default function ManagerSessionsPage() {
               <button
                 type="button"
                 onClick={resetStatuses}
-                className="text-xs font-medium text-blue-600 hover:underline"
+                className="text-xs font-medium text-brand hover:underline"
               >
                 Active only
               </button>
@@ -167,7 +167,7 @@ export default function ManagerSessionsPage() {
                     onClick={() => toggleStatus(s)}
                     className={
                       on
-                        ? "rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white"
+                        ? "rounded-full bg-brand px-3 py-1 text-xs font-medium text-white"
                         : "rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-accent"
                     }
                   >

--- a/src/app/manager/(panel)/subjects/page.tsx
+++ b/src/app/manager/(panel)/subjects/page.tsx
@@ -114,8 +114,8 @@ export default function ManagerSubjectsPage() {
     <div className="space-y-6">
       <header className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <BookMarked className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <BookMarked className="size-6 text-brand" aria-hidden="true" />
             Subjects
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -159,7 +159,7 @@ export default function ManagerSubjectsPage() {
         <div className="space-y-5">
           {groups.map((group) => (
             <section key={group.name}>
-              <h2 className="mb-2 text-sm font-semibold text-muted-foreground">{group.name}</h2>
+              <h2 className="mb-2 font-display text-sm font-semibold tracking-tight text-muted-foreground">{group.name}</h2>
               <Card className="overflow-hidden p-0">
                 <ul className="divide-y">
                   {group.items.map((s) => (
@@ -236,7 +236,7 @@ function SubjectRow({
             </span>
           ) : null}
         </p>
-        <p className="mt-0.5 text-xs text-muted-foreground">
+        <p className="mt-0.5 text-xs text-muted-foreground tabular-nums">
           {subject.open_sessions} open · {subject.approved_members} approved
         </p>
       </div>

--- a/src/app/manager/(panel)/verification/page.tsx
+++ b/src/app/manager/(panel)/verification/page.tsx
@@ -79,8 +79,8 @@ export default function ManagerVerificationPage() {
   return (
     <div className="space-y-6">
       <header>
-        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-          <BadgeCheck className="size-6 text-blue-600" aria-hidden="true" />
+        <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+          <BadgeCheck className="size-6 text-brand" aria-hidden="true" />
           Verification
         </h1>
         <p className="mt-1 text-sm text-muted-foreground">
@@ -161,9 +161,9 @@ function QueueGroup({
   return (
     <section>
       <div className="mb-3">
-        <h2 className="text-lg font-semibold">
+        <h2 className="font-display text-lg font-semibold tracking-tight">
           {title}
-          <span className="ml-2 text-sm font-normal text-muted-foreground">({sessions.length})</span>
+          <span className="ml-2 text-sm font-normal text-muted-foreground tabular-nums">({sessions.length})</span>
         </h2>
         <p className="text-sm text-muted-foreground">{subtitle}</p>
       </div>
@@ -194,7 +194,7 @@ function QueueGroup({
                       href={s.recording_url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:underline"
+                      className="inline-flex items-center gap-1 text-xs font-medium text-brand hover:underline"
                     >
                       <ExternalLink className="size-3.5" aria-hidden="true" />
                       Recording

--- a/src/app/member/approvals/page.tsx
+++ b/src/app/member/approvals/page.tsx
@@ -156,8 +156,8 @@ function ApprovalsInner() {
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-8">
 
-      <h1 className="mb-1 flex items-center gap-2 text-2xl font-bold tracking-tight">
-        <ShieldCheck className="size-6 text-blue-600" aria-hidden="true" />
+      <h1 className="mb-1 flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+        <ShieldCheck className="size-6 text-brand" aria-hidden="true" />
         Subject approvals
       </h1>
       <p className="mb-6 text-sm text-muted-foreground">
@@ -168,7 +168,7 @@ function ApprovalsInner() {
       {/* --- Request form --- */}
       <Card className="mb-8">
         <CardHeader>
-          <CardTitle className="text-base">Request a new approval</CardTitle>
+          <CardTitle className="font-display tracking-tight text-base">Request a new approval</CardTitle>
         </CardHeader>
         <CardContent>
           {requestable.length === 0 && !loading ? (
@@ -230,7 +230,7 @@ function ApprovalsInner() {
       </Card>
 
       {/* --- My approvals --- */}
-      <h2 className="mb-3 text-lg font-semibold">My approvals</h2>
+      <h2 className="mb-3 font-display text-lg font-semibold tracking-tight">My approvals</h2>
       {loading ? (
         <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />
@@ -287,7 +287,7 @@ function ApprovalRow({
               <p className="font-medium text-foreground">{subjectLabel(approval)}</p>
               {approval.direct_grant ? (
                 <p className="mt-0.5 inline-flex items-center gap-1 text-xs text-muted-foreground">
-                  <BadgeCheck className="size-3.5 text-blue-600" aria-hidden="true" />
+                  <BadgeCheck className="size-3.5 text-brand" aria-hidden="true" />
                   Granted by a manager
                 </p>
               ) : approval.evidence ? (

--- a/src/app/member/board/page.tsx
+++ b/src/app/member/board/page.tsx
@@ -140,8 +140,8 @@ export default function MemberBoardPage() {
 
       <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
         <div>
-          <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight">
-            <ClipboardList className="size-6 text-blue-600" aria-hidden="true" />
+          <h1 className="flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+            <ClipboardList className="size-6 text-brand" aria-hidden="true" />
             Tutoring board
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
@@ -151,7 +151,7 @@ export default function MemberBoardPage() {
         <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground">
           <input
             type="checkbox"
-            className="size-4 rounded border-input accent-blue-600"
+            className="size-4 rounded border-input accent-[oklch(0.56_0.114_159)]"
             checked={onlyClaimable}
             onChange={(e) => toggleOnlyClaimable(e.target.checked)}
           />
@@ -270,7 +270,7 @@ function BoardCard({
                 </Button>
                 <Link
                   href={`/member/approvals?subject=${encodeURIComponent(item.org_subject_id)}`}
-                  className="inline-flex items-center justify-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700"
+                  className="inline-flex items-center justify-center gap-1 text-xs font-medium text-brand hover:text-brand-strong"
                 >
                   Request approval
                   <ArrowRight className="size-3" aria-hidden="true" />

--- a/src/app/member/dashboard/page.tsx
+++ b/src/app/member/dashboard/page.tsx
@@ -185,7 +185,7 @@ function ActiveDashboard() {
   return (
     <div className="space-y-8">
       <header>
-        <h1 className="text-2xl font-semibold tracking-tight text-foreground">
+        <h1 className="font-display text-2xl font-semibold tracking-tight text-foreground">
           Welcome back, {profile.first_name}
         </h1>
         <p className="text-sm text-muted-foreground">
@@ -206,10 +206,10 @@ function ActiveDashboard() {
       ) : null}
 
       {showNudge ? (
-        <Alert className="relative border-blue-200 bg-blue-50 text-blue-900">
-          <BadgeCheck className="size-4 text-blue-600" />
+        <Alert className="relative border-brand/30 bg-brand-subtle text-brand-strong">
+          <BadgeCheck className="size-4 text-brand" />
           <AlertTitle>Complete your profile</AlertTitle>
-          <AlertDescription className="text-blue-800">
+          <AlertDescription className="text-brand-strong">
             <span>
               Add your grade and pronouns so tutors know who they&apos;re helping.{" "}
               <Link
@@ -224,7 +224,7 @@ function ActiveDashboard() {
             type="button"
             onClick={dismissNudge}
             aria-label="Dismiss"
-            className="absolute top-2 right-2 rounded-md p-1 text-blue-700 hover:bg-blue-100"
+            className="absolute top-2 right-2 rounded-md p-1 text-brand-strong hover:bg-brand-subtle"
           >
             <X className="size-4" />
           </button>
@@ -236,7 +236,9 @@ function ActiveDashboard() {
 
       {/* Quick actions */}
       <section className="space-y-3">
-        <h2 className="text-lg font-semibold text-foreground">Quick actions</h2>
+        <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">
+          Quick actions
+        </h2>
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <ActionCard
             icon={HandHelping}
@@ -333,14 +335,14 @@ function StatGrid({
         return (
           <Card key={s.label} className="gap-2 py-5">
             <CardContent className="space-y-2">
-              <span className="flex size-9 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+              <span className="flex size-9 items-center justify-center rounded-lg bg-brand-subtle text-brand">
                 <Icon className="size-5" aria-hidden="true" />
               </span>
               <p
                 className={
                   loading
-                    ? "text-2xl font-semibold text-muted-foreground"
-                    : "text-2xl font-semibold text-foreground"
+                    ? "font-display text-2xl font-semibold tabular-nums tracking-tight text-muted-foreground"
+                    : "font-display text-2xl font-semibold tabular-nums tracking-tight text-foreground"
                 }
               >
                 {s.value}
@@ -373,7 +375,9 @@ function MyRequests({
 
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">My requests</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">
+        My requests
+      </h2>
       {loading && sessions.length === 0 ? (
         <SkeletonRows />
       ) : sessions.length === 0 ? (
@@ -449,7 +453,9 @@ function MySessions({
 
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">My sessions</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">
+        My sessions
+      </h2>
       {loading && sessions.length === 0 ? (
         <SkeletonRows />
       ) : sessions.length === 0 ? (
@@ -679,7 +685,9 @@ function PastSessions({
 
   return (
     <section className="space-y-3">
-      <h2 className="text-lg font-semibold text-foreground">Past sessions</h2>
+      <h2 className="font-display text-lg font-semibold tracking-tight text-foreground">
+        Past sessions
+      </h2>
       <ul className="space-y-2">
         {sessions.map((s) => {
           const counterpart =
@@ -704,7 +712,7 @@ function PastSessions({
                 </p>
               </div>
               {s.status === "verified" && s.awarded_hours != null ? (
-                <span className="text-sm font-medium text-green-700">
+                <span className="text-sm font-medium tabular-nums text-green-700">
                   +{formatHours(s.awarded_hours)} h
                 </span>
               ) : null}

--- a/src/app/member/profile/page.tsx
+++ b/src/app/member/profile/page.tsx
@@ -31,8 +31,8 @@ export default function MemberProfilePage() {
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-8">
 
-      <h1 className="mb-6 flex items-center gap-2 text-2xl font-bold tracking-tight">
-        <UserCircle className="size-6 text-blue-600" aria-hidden="true" />
+      <h1 className="mb-6 flex items-center gap-2 font-display text-2xl font-bold tracking-tight">
+        <UserCircle className="size-6 text-brand" aria-hidden="true" />
         Profile
       </h1>
 
@@ -108,7 +108,7 @@ function DetailsForm({
   return (
     <Card className="mb-8">
       <CardHeader>
-        <CardTitle className="text-base">Your details</CardTitle>
+        <CardTitle className="font-display tracking-tight text-base">Your details</CardTitle>
       </CardHeader>
       <CardContent>
         <form className="space-y-4" onSubmit={handleSave}>
@@ -228,7 +228,7 @@ function PasswordForm() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Change password</CardTitle>
+        <CardTitle className="font-display tracking-tight text-base">Change password</CardTitle>
       </CardHeader>
       <CardContent>
         <form className="space-y-4" onSubmit={handleSave}>

--- a/src/app/member/request/page.tsx
+++ b/src/app/member/request/page.tsx
@@ -163,8 +163,8 @@ export default function MemberRequestPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <HelpCircle className="size-5 text-blue-600" aria-hidden="true" />
+          <CardTitle className="flex items-center gap-2 font-display tracking-tight">
+            <HelpCircle className="size-5 text-brand" aria-hidden="true" />
             Get help
           </CardTitle>
           <p className="text-sm text-muted-foreground">
@@ -261,7 +261,7 @@ export default function MemberRequestPage() {
                 <label className="flex items-center gap-2 text-sm font-medium">
                   <input
                     type="checkbox"
-                    className="size-4 rounded border-input accent-blue-600"
+                    className="size-4 rounded border-input accent-[oklch(0.56_0.114_159)]"
                     checked={isEll}
                     onChange={(e) => setIsEll(e.target.checked)}
                   />
@@ -299,7 +299,7 @@ export default function MemberRequestPage() {
                       className={
                         "flex flex-1 cursor-pointer items-center justify-center gap-2 rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors " +
                         (location === opt.value
-                          ? "border-blue-600 bg-blue-50 text-blue-700"
+                          ? "border-brand bg-brand-subtle text-brand-strong"
                           : "border-input text-muted-foreground hover:bg-muted/40")
                       }
                     >

--- a/src/app/member/sessions/[id]/availability/page.tsx
+++ b/src/app/member/sessions/[id]/availability/page.tsx
@@ -131,8 +131,8 @@ export default function MemberAvailabilityPage({
 
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <CalendarClock className="size-5 text-blue-600" aria-hidden="true" />
+          <CardTitle className="flex items-center gap-2 font-display tracking-tight">
+            <CalendarClock className="size-5 text-brand" aria-hidden="true" />
             Set your availability
           </CardTitle>
           {session ? (

--- a/src/app/member/sessions/[id]/schedule/page.tsx
+++ b/src/app/member/sessions/[id]/schedule/page.tsx
@@ -150,8 +150,8 @@ export default function MemberSchedulePage({
 
       <Card>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <CalendarCheck className="size-5 text-blue-600" aria-hidden="true" />
+          <CardTitle className="flex items-center gap-2 font-display tracking-tight">
+            <CalendarCheck className="size-5 text-brand" aria-hidden="true" />
             Schedule the session
           </CardTitle>
           {session ? (

--- a/src/app/member/tutorial/page.tsx
+++ b/src/app/member/tutorial/page.tsx
@@ -72,7 +72,7 @@ export default function MemberTutorialPage() {
 
   return (
     <div className="mx-auto w-full max-w-2xl px-4 py-8">
-      <h1 className="mb-1 text-2xl font-bold tracking-tight">How it works</h1>
+      <h1 className="mb-1 font-display text-2xl font-bold tracking-tight">How it works</h1>
       <p className="mb-6 text-sm text-muted-foreground">
         One account, two ways to take part — get help with your own work, and tutor the
         subjects you&apos;re approved for.
@@ -112,11 +112,11 @@ export default function MemberTutorialPage() {
           <li key={step.title}>
             <Card>
               <CardContent className="flex gap-4">
-                <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-blue-50 text-blue-600">
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-brand">
                   <step.icon className="size-5" aria-hidden="true" />
                 </span>
                 <div>
-                  <p className="font-medium text-foreground">
+                  <p className="font-display font-medium tracking-tight text-foreground">
                     {i + 1}. {step.title}
                   </p>
                   <p className="mt-1 text-sm text-muted-foreground">{step.body}</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   ClipboardList,
   CalendarDays,
   BadgeCheck,
+  ArrowRight,
 } from "lucide-react";
 import { BRAND } from "@/lib/brand";
 import { BrandMark, BrandWordmark } from "@/components/brand";
@@ -86,46 +87,42 @@ const FAQ = [
 
 export default function Home() {
   return (
-    <div className="relative min-h-screen overflow-hidden bg-white text-gray-900">
-      {/* Decorative background */}
+    <div className="relative min-h-screen overflow-hidden bg-background text-foreground">
+      {/* Atmosphere — emerald light from the top + faint grid. No gradient blobs. */}
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-32 -left-32 h-[40rem] w-[40rem] rounded-full bg-gradient-to-tr from-blue-200 via-indigo-200 to-purple-200 opacity-70 blur-3xl motion-safe:animate-pulse" />
-        <div className="absolute -bottom-32 -right-32 h-[40rem] w-[40rem] rounded-full bg-gradient-to-tr from-indigo-200 via-purple-200 to-pink-200 opacity-70 blur-3xl motion-safe:animate-pulse" />
+        <div className="absolute inset-x-0 top-0 h-[42rem] bg-[radial-gradient(60%_100%_at_50%_0%,var(--brand-subtle),transparent_70%)]" />
+        <div className="absolute inset-0 opacity-60 [mask-image:linear-gradient(to_bottom,black,transparent_45%)] bg-[linear-gradient(to_right,oklch(0.5_0.01_160/0.045)_1px,transparent_1px),linear-gradient(to_bottom,oklch(0.5_0.01_160/0.045)_1px,transparent_1px)] [background-size:48px_48px]" />
       </div>
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] opacity-40 [background-size:16px_16px]"
-      />
 
       {/* Header */}
-      <header className="relative z-10">
-        <nav className="mx-auto flex max-w-7xl items-center justify-between px-6 py-5">
+      <header className="sticky top-0 z-30 border-b border-border/60 bg-background/80 backdrop-blur-md">
+        <nav className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <Link
             href="/"
-            className="flex items-center gap-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="flex items-center gap-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <BrandMark className="h-8 w-8" />
             <BrandWordmark className="text-xl" />
           </Link>
-          <div className="flex items-center gap-2">
-            <div className="mr-2 hidden items-center gap-6 text-sm font-medium text-gray-600 md:flex">
+          <div className="flex items-center gap-1.5">
+            <div className="mr-3 hidden items-center gap-7 text-sm font-medium text-muted-foreground md:flex">
               <a
                 href="#how-it-works"
-                className="rounded-md transition-colors hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                className="rounded-md transition-colors hover:text-foreground"
               >
                 How it works
               </a>
               <a
                 href="#for-schools"
-                className="rounded-md transition-colors hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                className="rounded-md transition-colors hover:text-foreground"
               >
                 For schools
               </a>
             </div>
-            <Button asChild variant="ghost">
+            <Button asChild variant="ghost" size="sm">
               <Link href="/auth/login">Log in</Link>
             </Button>
-            <Button asChild>
+            <Button asChild size="sm">
               <Link href="/auth/register">Get started</Link>
             </Button>
           </div>
@@ -134,49 +131,87 @@ export default function Home() {
 
       <main className="relative z-10">
         {/* Hero */}
-        <section className="mx-auto max-w-4xl px-6 pb-16 pt-12 text-center sm:pt-20">
-          <span className="inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700 ring-1 ring-inset ring-blue-200">
+        <section className="mx-auto max-w-4xl px-6 pb-20 pt-16 text-center sm:pt-24">
+          <span
+            className="animate-rise-in inline-flex items-center gap-2 rounded-full border border-brand/20 bg-brand-subtle px-3.5 py-1.5 text-xs font-semibold tracking-tight text-brand-strong"
+            style={{ animationDelay: "0ms" }}
+          >
+            <span className="size-1.5 rounded-full bg-brand" />
             One account. Learn and tutor.
           </span>
-          <h1 className="mt-5 text-4xl font-extrabold tracking-tight text-gray-900 sm:text-6xl">
-            Peer tutoring, organized.
+          <h1
+            className="animate-rise-in font-display mt-6 text-5xl font-bold leading-[1.02] tracking-[-0.03em] text-foreground sm:text-7xl"
+            style={{ animationDelay: "70ms" }}
+          >
+            Peer tutoring,
+            <br />
+            <span className="text-brand">organized.</span>
           </h1>
-          <p className="mx-auto mt-5 max-w-2xl text-lg leading-8 text-gray-600">
-            Scire runs your school or club&apos;s tutoring program: post a
-            request when you need help, tutor the subjects you&apos;re approved
-            for, and get every volunteer hour verified — all in one place.
+          <p
+            className="animate-rise-in mx-auto mt-6 max-w-2xl text-lg leading-8 text-muted-foreground"
+            style={{ animationDelay: "140ms" }}
+          >
+            Scire runs your school or club&apos;s tutoring program: post a request
+            when you need help, tutor the subjects you&apos;re approved for, and
+            get every volunteer hour verified — all in one place.
           </p>
-          <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-            <Button asChild size="lg">
-              <Link href="/auth/register">Create your account</Link>
+          <div
+            className="animate-rise-in mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row"
+            style={{ animationDelay: "210ms" }}
+          >
+            <Button asChild size="lg" className="group">
+              <Link href="/auth/register">
+                Create your account
+                <ArrowRight className="transition-transform duration-200 group-hover:translate-x-0.5" />
+              </Link>
             </Button>
             <Button asChild size="lg" variant="outline">
               <Link href="/auth/login">Log in</Link>
             </Button>
           </div>
-          <p className="mt-4 text-sm text-gray-500">
+          <p
+            className="animate-rise-in mt-5 text-sm text-muted-foreground"
+            style={{ animationDelay: "280ms" }}
+          >
             Free for students. Any email address works.
           </p>
+
+          {/* Quick value strip */}
+          <ul
+            className="animate-rise-in mx-auto mt-12 flex max-w-2xl flex-wrap items-center justify-center gap-x-6 gap-y-3 text-sm font-medium text-muted-foreground"
+            style={{ animationDelay: "350ms" }}
+          >
+            {["Manager-approved subjects", "Built-in scheduling", "Verified hours"].map(
+              (item) => (
+                <li key={item} className="flex items-center gap-2">
+                  <BadgeCheck className="size-4 text-brand" aria-hidden />
+                  {item}
+                </li>
+              ),
+            )}
+          </ul>
         </section>
 
         {/* Why Scire? */}
-        <section className="mx-auto max-w-7xl px-6 py-16">
-          <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900">
+        <section className="mx-auto max-w-6xl px-6 py-16">
+          <h2 className="font-display text-center text-3xl font-semibold tracking-tight text-foreground">
             Why Scire?
           </h2>
-          <ul className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3">
+          <ul className="mt-12 grid grid-cols-1 gap-5 md:grid-cols-3">
             {WHY_CARDS.map(({ icon: Icon, title, body }) => (
               <li
                 key={title}
-                className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm"
+                className="group rounded-2xl border border-border bg-card p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-brand/30 hover:shadow-md"
               >
-                <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-blue-50 text-blue-600">
-                  <Icon aria-hidden className="h-6 w-6" />
+                <div className="flex size-11 items-center justify-center rounded-xl bg-brand-subtle text-brand ring-1 ring-inset ring-brand/15 transition-transform duration-200 group-hover:scale-105">
+                  <Icon aria-hidden className="size-6" />
                 </div>
-                <h3 className="mt-4 text-lg font-semibold text-gray-900">
+                <h3 className="font-display mt-5 text-lg font-semibold tracking-tight text-foreground">
                   {title}
                 </h3>
-                <p className="mt-2 text-sm leading-6 text-gray-600">{body}</p>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  {body}
+                </p>
               </li>
             ))}
           </ul>
@@ -185,90 +220,106 @@ export default function Home() {
         {/* How it works */}
         <section
           id="how-it-works"
-          className="mx-auto max-w-7xl scroll-mt-20 px-6 py-16"
+          className="mx-auto max-w-6xl scroll-mt-20 px-6 py-16"
         >
-          <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900">
+          <h2 className="font-display text-center text-3xl font-semibold tracking-tight text-foreground">
             How it works
           </h2>
-          <ol className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <ol className="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-4">
             {STEPS.map(({ icon: Icon, title, body }, i) => (
               <li
                 key={title}
-                className="relative rounded-2xl border border-gray-100 bg-white p-6 shadow-sm"
+                className="relative rounded-2xl border border-border bg-card p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
               >
                 <div className="flex items-center gap-3">
-                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-blue-600 text-sm font-bold text-white">
+                  <span className="font-display flex size-9 shrink-0 items-center justify-center rounded-full bg-foreground text-sm font-bold text-background tabular-nums">
                     {i + 1}
                   </span>
-                  <Icon aria-hidden className="h-5 w-5 text-blue-600" />
+                  <Icon aria-hidden className="size-5 text-brand" />
                 </div>
-                <h3 className="mt-4 text-base font-semibold text-gray-900">
+                <h3 className="font-display mt-5 text-base font-semibold tracking-tight text-foreground">
                   {title}
                 </h3>
-                <p className="mt-2 text-sm leading-6 text-gray-600">{body}</p>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  {body}
+                </p>
               </li>
             ))}
           </ol>
         </section>
 
-        {/* For schools & tutoring clubs */}
-        <section
-          id="for-schools"
-          className="scroll-mt-20 bg-gradient-to-b from-blue-50/60 to-indigo-50/60 py-20"
-        >
-          <div className="mx-auto max-w-4xl px-6 text-center">
-            <h2 className="text-3xl font-bold tracking-tight text-gray-900">
-              Run your program on Scire
-            </h2>
-            <p className="mx-auto mt-4 max-w-2xl text-lg leading-8 text-gray-600">
-              Each organization is its own private space — the members you admit,
-              a subject catalog you define, and the hours you verify.
-            </p>
-            <ul className="mx-auto mt-6 grid max-w-2xl grid-cols-1 gap-3 text-left sm:grid-cols-3">
-              <li className="rounded-xl bg-white/70 px-4 py-3 text-sm font-medium text-gray-700 ring-1 ring-inset ring-blue-100">
-                Members you admit
-              </li>
-              <li className="rounded-xl bg-white/70 px-4 py-3 text-sm font-medium text-gray-700 ring-1 ring-inset ring-blue-100">
-                A subject catalog you define
-              </li>
-              <li className="rounded-xl bg-white/70 px-4 py-3 text-sm font-medium text-gray-700 ring-1 ring-inset ring-blue-100">
-                Hours you verify
-              </li>
-            </ul>
-            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-              <Button asChild size="lg">
-                <Link href="/auth/register/manager">Register as a manager</Link>
-              </Button>
-              <Button asChild size="lg" variant="outline">
-                <Link href="/auth/login/manager">Manager sign in</Link>
-              </Button>
+        {/* For schools & tutoring clubs — confident dark band */}
+        <section id="for-schools" className="scroll-mt-20 px-6 py-16">
+          <div className="relative mx-auto max-w-6xl overflow-hidden rounded-3xl bg-foreground px-6 py-16 text-background sm:px-12">
+            {/* subtle emerald glow inside the dark panel */}
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-0 -z-0 bg-[radial-gradient(50%_80%_at_85%_0%,oklch(0.56_0.114_159/0.35),transparent_70%)]"
+            />
+            <div className="relative mx-auto max-w-2xl text-center">
+              <span className="inline-flex items-center gap-2 rounded-full border border-background/20 bg-background/10 px-3.5 py-1.5 text-xs font-semibold tracking-tight text-background/90">
+                For schools &amp; tutoring clubs
+              </span>
+              <h2 className="font-display mt-5 text-3xl font-semibold tracking-tight sm:text-4xl">
+                Run your program on Scire
+              </h2>
+              <p className="mx-auto mt-4 max-w-2xl text-lg leading-8 text-background/70">
+                Each organization is its own private space — the members you
+                admit, a subject catalog you define, and the hours you verify.
+              </p>
+              <ul className="mx-auto mt-8 grid max-w-2xl grid-cols-1 gap-3 text-left sm:grid-cols-3">
+                {["Members you admit", "A subject catalog you define", "Hours you verify"].map(
+                  (item) => (
+                    <li
+                      key={item}
+                      className="flex items-center gap-2 rounded-xl border border-background/10 bg-background/5 px-4 py-3 text-sm font-medium text-background/90"
+                    >
+                      <BadgeCheck className="size-4 shrink-0 text-brand" aria-hidden />
+                      {item}
+                    </li>
+                  ),
+                )}
+              </ul>
+              <div className="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
+                <Button asChild size="lg" variant="secondary">
+                  <Link href="/auth/register/manager">Register as a manager</Link>
+                </Button>
+                <Button
+                  asChild
+                  size="lg"
+                  variant="outline"
+                  className="border-background/25 bg-transparent text-background hover:bg-background/10 hover:text-background"
+                >
+                  <Link href="/auth/login/manager">Manager sign in</Link>
+                </Button>
+              </div>
+              <p className="mx-auto mt-7 max-w-xl text-sm text-background/60">
+                New organizations are set up by the Scire team. Want your school
+                or club on Scire? Email{" "}
+                <a
+                  href={`mailto:${BRAND.contactEmail}`}
+                  className="font-medium text-background underline-offset-4 hover:underline"
+                >
+                  {BRAND.contactEmail}
+                </a>
+                .
+              </p>
             </div>
-            <p className="mx-auto mt-6 max-w-xl text-sm text-gray-500">
-              New organizations are set up by the Scire team. Want your school or
-              club on Scire? Email{" "}
-              <a
-                href={`mailto:${BRAND.contactEmail}`}
-                className="font-medium text-blue-600 underline-offset-4 hover:underline"
-              >
-                {BRAND.contactEmail}
-              </a>
-              .
-            </p>
           </div>
         </section>
 
         {/* FAQ */}
         <section className="mx-auto max-w-3xl px-6 py-20">
-          <h2 className="text-center text-3xl font-bold tracking-tight text-gray-900">
+          <h2 className="font-display text-center text-3xl font-semibold tracking-tight text-foreground">
             Frequently asked questions
           </h2>
-          <Accordion type="single" collapsible className="mt-8 w-full">
+          <Accordion type="single" collapsible className="mt-10 w-full">
             {FAQ.map(({ q, a }) => (
               <AccordionItem key={q} value={q}>
-                <AccordionTrigger className="text-left text-base font-semibold">
+                <AccordionTrigger className="font-display text-left text-base font-semibold tracking-tight">
                   {q}
                 </AccordionTrigger>
-                <AccordionContent className="text-sm leading-6 text-gray-600">
+                <AccordionContent className="text-sm leading-6 text-muted-foreground">
                   {a}
                 </AccordionContent>
               </AccordionItem>
@@ -278,29 +329,32 @@ export default function Home() {
       </main>
 
       {/* Footer */}
-      <footer className="border-t border-gray-100 bg-white">
-        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-6 py-12 sm:flex-row sm:items-start sm:justify-between">
+      <footer className="border-t border-border bg-card">
+        <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-12 sm:flex-row sm:items-start sm:justify-between">
           <div className="max-w-sm">
-            <BrandWordmark className="text-lg" />
-            <p className="mt-2 text-sm italic text-gray-500">
+            <div className="flex items-center gap-2">
+              <BrandMark className="h-7 w-7" />
+              <BrandWordmark className="text-lg" />
+            </div>
+            <p className="mt-3 text-sm italic text-muted-foreground">
               Scire — from the Latin <span className="italic">scire</span>, &quot;to
               know.&quot;
             </p>
-            <p className="mt-3 text-sm text-gray-500">
+            <p className="mt-3 text-sm">
               <a
                 href={`mailto:${BRAND.contactEmail}`}
-                className="font-medium text-blue-600 underline-offset-4 hover:underline"
+                className="font-medium text-brand underline-offset-4 hover:underline"
               >
                 {BRAND.contactEmail}
               </a>
             </p>
           </div>
           <nav aria-label="Footer">
-            <ul className="flex flex-col gap-2 text-sm text-gray-600 sm:items-end">
+            <ul className="flex flex-col gap-2.5 text-sm text-muted-foreground sm:items-end">
               <li>
                 <Link
                   href="/auth/login"
-                  className="rounded transition-colors hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  className="rounded transition-colors hover:text-foreground"
                 >
                   Log in
                 </Link>
@@ -308,7 +362,7 @@ export default function Home() {
               <li>
                 <Link
                   href="/auth/register"
-                  className="rounded transition-colors hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  className="rounded transition-colors hover:text-foreground"
                 >
                   Create account
                 </Link>
@@ -316,7 +370,7 @@ export default function Home() {
               <li>
                 <Link
                   href="/auth/register/manager"
-                  className="rounded transition-colors hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                  className="rounded transition-colors hover:text-foreground"
                 >
                   Manager registration
                 </Link>

--- a/src/components/action-card.tsx
+++ b/src/components/action-card.tsx
@@ -35,11 +35,11 @@ export function ActionCard({
         "group h-full gap-3 px-5 py-5 text-left transition-shadow",
         disabled
           ? "cursor-not-allowed opacity-50"
-          : "hover:border-blue-300 hover:shadow-md",
+          : "hover:border-brand/40 hover:shadow-md",
         className,
       )}
     >
-      <span className="flex size-10 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+      <span className="flex size-10 items-center justify-center rounded-lg bg-brand-subtle text-brand">
         <Icon className="size-5" aria-hidden="true" />
       </span>
       <div className="space-y-1">

--- a/src/components/admin-shell.tsx
+++ b/src/components/admin-shell.tsx
@@ -119,7 +119,7 @@ export function AdminShell({
               className={cn(
                 "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                 active
-                  ? "bg-blue-50 text-blue-700"
+                  ? "bg-brand-subtle text-brand-strong"
                   : "text-foreground/80 hover:bg-accent hover:text-foreground",
               )}
             >
@@ -132,7 +132,7 @@ export function AdminShell({
 
       <div className="border-t px-3 py-3">
         <div className="flex items-center gap-3 px-2 py-1">
-          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 uppercase">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-sm font-semibold text-brand-strong uppercase">
             {(initialProfile.first_name[0] ?? "") + (initialProfile.last_name[0] ?? "") || "?"}
           </span>
           <div className="min-w-0 flex-1">

--- a/src/components/admin/create-org-dialog.tsx
+++ b/src/components/admin/create-org-dialog.tsx
@@ -187,7 +187,7 @@ function CreateOrgForm({
   return (
     <form onSubmit={handleSubmit}>
       <DialogHeader>
-        <DialogTitle>Create organization</DialogTitle>
+        <DialogTitle className="font-display tracking-tight">Create organization</DialogTitle>
         <DialogDescription>
           The chosen template subjects are copied into the new org&apos;s catalog. Managers can edit
           the catalog afterward.
@@ -247,7 +247,7 @@ function CreateOrgForm({
           <div className="flex items-center gap-3 text-xs">
             <button
               type="button"
-              className="font-medium text-blue-600 hover:underline disabled:opacity-50"
+              className="font-medium text-brand hover:underline disabled:opacity-50"
               onClick={selectAllFiltered}
               disabled={pending || templateLoading}
             >

--- a/src/components/admin/session-dialogs.tsx
+++ b/src/components/admin/session-dialogs.tsx
@@ -97,7 +97,7 @@ function VerifyForm({
   return (
     <form onSubmit={handleSubmit}>
       <DialogHeader>
-        <DialogTitle>Verify session</DialogTitle>
+        <DialogTitle className="font-display tracking-tight">Verify session</DialogTitle>
         <DialogDescription>
           Confirm the session happened and award volunteer hours to the tutor. This is final —
           corrections are made later as ledger adjustments.
@@ -127,7 +127,7 @@ function VerifyForm({
             href={session.recording_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-brand hover:underline"
           >
             <ExternalLink className="size-4" aria-hidden="true" />
             Open recording in a new tab
@@ -237,7 +237,7 @@ export function AdminCancelSessionDialog({
       <DialogContent className="sm:max-w-md">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Cancel this session</DialogTitle>
+            <DialogTitle className="font-display tracking-tight">Cancel this session</DialogTitle>
             <DialogDescription>
               Both the requester and the tutor will be emailed. This cannot be undone.
             </DialogDescription>

--- a/src/components/admin/session-list.tsx
+++ b/src/components/admin/session-list.tsx
@@ -160,7 +160,7 @@ export function SessionList({
                 onClick={() => toggleStatus(s)}
                 className={
                   on
-                    ? "rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white"
+                    ? "rounded-full bg-brand px-3 py-1 text-xs font-medium text-white"
                     : "rounded-full bg-muted px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-accent"
                 }
               >
@@ -310,7 +310,7 @@ function SessionRow({
               href={session.recording_url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+              className="inline-flex items-center gap-1.5 text-sm font-medium text-brand hover:underline"
             >
               <ExternalLink className="size-4" aria-hidden="true" />
               Open recording

--- a/src/components/auth-shell.tsx
+++ b/src/components/auth-shell.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { BrandMark } from "@/components/brand";
+import { BrandMark, BrandWordmark } from "@/components/brand";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
@@ -15,8 +15,10 @@ type AuthShellProps = {
 };
 
 /**
- * Centered auth card on the Scire gradient backdrop. The BrandMark links home.
- * Shared by every /auth/** page so they read as one surface.
+ * Centered auth card on the Scire "Confident SaaS" canvas: warm off-white, a
+ * faint emerald wash from the top, and a hairline grid — no gradient blobs. The
+ * BrandMark + wordmark link home. Shared by every /auth/** page so they read as
+ * one surface.
  */
 export function AuthShell({
   title,
@@ -27,38 +29,38 @@ export function AuthShell({
   className,
 }: AuthShellProps) {
   return (
-    <div className="relative grid min-h-screen place-items-center overflow-hidden bg-white px-4 py-10">
+    <div className="relative grid min-h-screen place-items-center overflow-hidden bg-background px-4 py-10">
+      {/* Atmosphere — emerald light from the top, faint grid texture. */}
       <div aria-hidden className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -top-32 -left-32 h-[40rem] w-[40rem] rounded-full bg-gradient-to-tr from-blue-200 via-indigo-200 to-purple-200 opacity-70 blur-3xl motion-safe:animate-pulse" />
-        <div className="absolute -bottom-32 -right-32 h-[40rem] w-[40rem] rounded-full bg-gradient-to-tr from-indigo-200 via-purple-200 to-pink-200 opacity-70 blur-3xl motion-safe:animate-pulse" />
+        <div className="absolute inset-x-0 top-0 h-[28rem] bg-[radial-gradient(70%_100%_at_50%_0%,var(--brand-subtle),transparent_72%)]" />
+        <div className="absolute inset-0 opacity-60 [mask-image:radial-gradient(120%_80%_at_50%_0%,black,transparent_70%)] bg-[linear-gradient(to_right,oklch(0.5_0.01_160/0.045)_1px,transparent_1px),linear-gradient(to_bottom,oklch(0.5_0.01_160/0.045)_1px,transparent_1px)] [background-size:44px_44px]" />
       </div>
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(#e5e7eb_1px,transparent_1px)] opacity-40 [background-size:16px_16px]"
-      />
 
-      <div className={cn("w-full max-w-md", className)}>
-        <Card className="shadow-xl">
+      <div className={cn("w-full max-w-md animate-rise-in", className)}>
+        <Card className="shadow-lg">
           <CardHeader className="items-center text-center">
             <Link
               href="/"
               aria-label="Scire home"
-              className="mx-auto rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+              className="mx-auto flex items-center gap-2 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <BrandMark className="h-11 w-11" />
+              <BrandMark className="h-10 w-10" />
+              <BrandWordmark className="text-xl" />
             </Link>
-            {badge ? <div className="mt-3">{badge}</div> : null}
-            <h1 className="mt-3 text-2xl font-bold tracking-tight text-gray-900">
+            {badge ? <div className="mt-4">{badge}</div> : null}
+            <h1 className="font-display mt-4 text-2xl font-semibold tracking-tight text-foreground">
               {title}
             </h1>
             {subtitle ? (
-              <p className="mt-1 text-sm text-gray-600">{subtitle}</p>
+              <p className="mt-1.5 text-sm text-muted-foreground">{subtitle}</p>
             ) : null}
           </CardHeader>
           <CardContent>{children}</CardContent>
         </Card>
         {footer ? (
-          <div className="mt-6 text-center text-sm text-gray-600">{footer}</div>
+          <div className="mt-6 text-center text-sm text-muted-foreground">
+            {footer}
+          </div>
         ) : null}
       </div>
     </div>

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -26,9 +26,9 @@ export function ForgotPasswordForm() {
 
   if (sentTo) {
     return (
-      <p className="text-center text-sm leading-6 text-gray-600">
+      <p className="text-center text-sm leading-6 text-muted-foreground">
         If an account exists for{" "}
-        <span className="font-medium text-gray-900">{sentTo}</span>, a reset link
+        <span className="font-medium text-foreground">{sentTo}</span>, a reset link
         is on its way.
       </p>
     );

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -100,7 +100,7 @@ export function LoginForm() {
           <Label htmlFor="password">Password</Label>
           <Link
             href="/auth/forgot-password"
-            className="text-sm font-medium text-blue-600 underline-offset-4 hover:underline"
+            className="text-sm font-medium text-brand underline-offset-4 hover:underline"
           >
             Forgot password?
           </Link>

--- a/src/components/auth/register-form.tsx
+++ b/src/components/auth/register-form.tsx
@@ -147,11 +147,11 @@ export function RegisterForm({ kind }: { kind: "member" | "manager" }) {
             ))}
           </SelectContent>
         </Select>
-        <p className="text-xs text-gray-500">
+        <p className="text-xs text-muted-foreground">
           Don&apos;t see your organization? Email{" "}
           <a
             href={`mailto:${BRAND.contactEmail}`}
-            className="font-medium text-blue-600 underline-offset-4 hover:underline"
+            className="font-medium text-brand underline-offset-4 hover:underline"
           >
             {BRAND.contactEmail}
           </a>

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -45,7 +45,7 @@ export function ResetPasswordForm() {
   if (done) {
     return (
       <div className="space-y-4 text-center">
-        <p className="text-sm leading-6 text-gray-600">Password updated.</p>
+        <p className="text-sm leading-6 text-muted-foreground">Password updated.</p>
         <Button asChild className="w-full">
           <Link href="/auth/login">Log in</Link>
         </Button>

--- a/src/components/auth/verify-email-resend.tsx
+++ b/src/components/auth/verify-email-resend.tsx
@@ -23,7 +23,7 @@ export function VerifyEmailResend({ email }: { email: string | null }) {
 
   if (!email) {
     return (
-      <p className="text-sm text-gray-500">
+      <p className="text-sm text-muted-foreground">
         Didn&apos;t get the email? Sign in to resend it.
       </p>
     );

--- a/src/components/brand.tsx
+++ b/src/components/brand.tsx
@@ -2,9 +2,10 @@ import { cn } from "@/lib/utils";
 import { BRAND } from "@/lib/brand";
 
 /**
- * Inline-SVG brand mark: a blue-600 rounded square with a white "S". No file
- * asset, so it renders identically server- and client-side. Drop real artwork
- * into `public/brand/` and swap only this component.
+ * Inline-SVG brand mark: an emerald rounded square with a lighter inset corner
+ * and a white display "S". No file asset, so it renders identically server- and
+ * client-side. Drop real artwork into `public/brand/` and swap only this
+ * component.
  */
 export function BrandMark({
   className,
@@ -22,15 +23,18 @@ export function BrandMark({
       aria-label={BRAND.name}
       className={cn("shrink-0", className)}
     >
-      <rect width="32" height="32" rx="8" className="fill-blue-600" />
+      <rect width="32" height="32" rx="9" className="fill-brand" />
+      {/* Soft inset highlight in the corner for a tactile, lit feel. */}
+      <path d="M32 0 H20 A12 12 0 0 1 32 12 Z" className="fill-white/15" />
       <text
         x="16"
-        y="17"
+        y="17.5"
         textAnchor="middle"
         dominantBaseline="central"
-        fontFamily="var(--font-inter), system-ui, sans-serif"
-        fontSize="20"
-        fontWeight="700"
+        fontFamily="var(--font-schibsted), var(--font-hanken), system-ui, sans-serif"
+        fontSize="19"
+        fontWeight="800"
+        letterSpacing="-0.5"
         className="fill-white"
       >
         S
@@ -39,12 +43,15 @@ export function BrandMark({
   );
 }
 
-/** Styled brand wordmark — the "Scire" name set in the brand color. */
+/**
+ * Styled brand wordmark — the "Scire" name set in the display face. Ink by
+ * default (pairs with the emerald mark); pass a color class to override.
+ */
 export function BrandWordmark({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "font-semibold tracking-tight text-blue-600",
+        "font-display font-semibold tracking-tight text-foreground",
         className,
       )}
     >

--- a/src/components/help-modal.tsx
+++ b/src/components/help-modal.tsx
@@ -90,8 +90,8 @@ export function HelpModal({
     >
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <LifeBuoy className="size-5 text-blue-600" aria-hidden="true" />
+          <DialogTitle className="flex items-center gap-2 font-display tracking-tight">
+            <LifeBuoy className="size-5 text-brand" aria-hidden="true" />
             Ask for help
           </DialogTitle>
           <DialogDescription>

--- a/src/components/manager-shell.tsx
+++ b/src/components/manager-shell.tsx
@@ -188,14 +188,14 @@ export function ManagerShell({
               className={cn(
                 "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                 active
-                  ? "bg-blue-50 text-blue-700"
+                  ? "bg-brand-subtle text-brand-strong"
                   : "text-foreground/80 hover:bg-accent hover:text-foreground",
               )}
             >
               <Icon className="size-4 shrink-0" aria-hidden="true" />
               <span className="flex-1">{item.label}</span>
               {item.badge && count > 0 ? (
-                <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-semibold text-white">
+                <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-brand px-1.5 text-xs font-semibold text-white">
                   {count}
                 </span>
               ) : null}
@@ -206,7 +206,7 @@ export function ManagerShell({
 
       <div className="border-t px-3 py-3">
         <div className="flex items-center gap-3 px-2 py-1">
-          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 uppercase">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-sm font-semibold text-brand-strong uppercase">
             {(initialProfile.first_name[0] ?? "") + (initialProfile.last_name[0] ?? "") || "?"}
           </span>
           <div className="min-w-0 flex-1">

--- a/src/components/manager/grant-subject-dialog.tsx
+++ b/src/components/manager/grant-subject-dialog.tsx
@@ -121,7 +121,7 @@ export function GrantSubjectDialog({
     >
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>Grant a subject to {memberName}</DialogTitle>
+          <DialogTitle className="font-display tracking-tight">Grant a subject to {memberName}</DialogTitle>
           <DialogDescription>
             Approve {memberName} to tutor a subject directly, without a request.
           </DialogDescription>
@@ -164,7 +164,7 @@ export function GrantSubjectDialog({
                         disabled={pending}
                         className={cn(
                           "flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm hover:bg-accent",
-                          isSel && "bg-blue-50 text-blue-700",
+                          isSel && "bg-brand-subtle text-brand-strong",
                         )}
                       >
                         <span>{subjectLabel(s)}</span>

--- a/src/components/manager/member-approvals-tab.tsx
+++ b/src/components/manager/member-approvals-tab.tsx
@@ -79,7 +79,7 @@ export function MemberApprovalsTab({
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold text-foreground">Subject approvals</h2>
+        <h2 className="font-display text-sm font-semibold tracking-tight text-foreground">Subject approvals</h2>
         <Button size="sm" onClick={() => setGrantOpen(true)}>
           <Plus className="size-4" aria-hidden="true" />
           Grant subject
@@ -147,7 +147,7 @@ export function MemberApprovalsTab({
       {/* History from the audit timeline */}
       {history.length > 0 ? (
         <section className="space-y-2">
-          <h3 className="text-sm font-semibold text-foreground">History</h3>
+          <h3 className="font-display text-sm font-semibold tracking-tight text-foreground">History</h3>
           <Card>
             <CardContent className="py-2">
               <ul className="divide-y">
@@ -216,8 +216,8 @@ function SourceChip({ direct }: { direct: boolean }) {
       className={cn(
         "inline-flex items-center rounded-full px-1.5 py-0.5 text-[11px] font-medium ring-1 ring-inset",
         direct
-          ? "bg-purple-50 text-purple-700 ring-purple-600/20"
-          : "bg-blue-50 text-blue-700 ring-blue-600/20",
+          ? "bg-slate-100 text-slate-600 ring-slate-500/20"
+          : "bg-brand-subtle text-brand-strong ring-brand/20",
       )}
     >
       {direct ? "Direct" : "Request"}

--- a/src/components/manager/member-hours-tab.tsx
+++ b/src/components/manager/member-hours-tab.tsx
@@ -65,11 +65,11 @@ export function MemberHoursTab({
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-3">
-          <span className="flex size-11 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
+          <span className="flex size-11 items-center justify-center rounded-lg bg-brand-subtle text-brand">
             <Clock className="size-5" aria-hidden="true" />
           </span>
           <div>
-            <p className="text-2xl font-semibold text-foreground">{formatHoursTotal(total)}</p>
+            <p className="font-display text-2xl font-semibold tracking-tight tabular-nums text-foreground">{formatHoursTotal(total)}</p>
             <p className="text-sm text-muted-foreground">Total volunteer hours</p>
           </div>
         </div>
@@ -134,7 +134,7 @@ export function MemberHoursTab({
                         {e.session_id ? (
                           <Link
                             href={`/manager/sessions/${e.session_id}`}
-                            className="text-blue-700 hover:underline"
+                            className="text-brand-strong hover:underline"
                           >
                             {e.note ?? "Session award"}
                           </Link>
@@ -172,7 +172,7 @@ function KindChip({ kind }: { kind: "award" | "adjustment" }) {
         "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
         kind === "award"
           ? "bg-green-50 text-green-700 ring-green-600/20"
-          : "bg-blue-50 text-blue-700 ring-blue-600/20",
+          : "bg-brand-subtle text-brand-strong ring-brand/20",
       )}
     >
       {kind === "award" ? "Award" : "Adjustment"}

--- a/src/components/manager/member-sessions-tab.tsx
+++ b/src/components/manager/member-sessions-tab.tsx
@@ -96,13 +96,13 @@ function SessionGroup({
   if (sessions.length === 0) return null;
   return (
     <section className="space-y-2">
-      <h3 className="text-sm font-semibold text-foreground">{title}</h3>
+      <h3 className="font-display text-sm font-semibold tracking-tight text-foreground">{title}</h3>
       <ul className="space-y-2">
         {sessions.map((s) => (
           <li key={s.id}>
             <Link
               href={`/manager/sessions/${s.id}`}
-              className="flex flex-wrap items-center gap-3 rounded-lg border bg-card px-4 py-3 transition-colors hover:border-blue-300"
+              className="flex flex-wrap items-center gap-3 rounded-lg border bg-card px-4 py-3 transition-colors hover:border-brand/40"
             >
               <div className="min-w-0 flex-1">
                 <p className="truncate font-medium text-foreground">{subjectLabel(s)}</p>

--- a/src/components/manager/ui.tsx
+++ b/src/components/manager/ui.tsx
@@ -65,12 +65,12 @@ export function formatHours(n: number): string {
 type Tone = "blue" | "amber" | "orange" | "green" | "red" | "purple" | "neutral";
 
 const TONE_CLASS: Record<Tone, string> = {
-  blue: "bg-blue-50 text-blue-700 ring-blue-600/20",
+  blue: "bg-sky-50 text-sky-700 ring-sky-600/20",
   amber: "bg-amber-50 text-amber-700 ring-amber-600/20",
   orange: "bg-orange-50 text-orange-700 ring-orange-600/20",
-  green: "bg-green-50 text-green-700 ring-green-600/20",
+  green: "bg-brand-subtle text-brand-strong ring-brand/25",
   red: "bg-red-50 text-red-700 ring-red-600/20",
-  purple: "bg-purple-50 text-purple-700 ring-purple-600/20",
+  purple: "bg-slate-100 text-slate-600 ring-slate-500/20",
   neutral: "bg-muted text-muted-foreground ring-border",
 };
 
@@ -190,7 +190,7 @@ export function TabBar<T extends string>({
               <span
                 className={cn(
                   "inline-flex min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-semibold",
-                  active ? "bg-blue-600 text-white" : "bg-muted-foreground/15 text-foreground",
+                  active ? "bg-brand text-white" : "bg-muted-foreground/15 text-foreground",
                 )}
               >
                 {t.count}
@@ -238,7 +238,7 @@ export function AvailabilityView({ availability }: { availability: Record<string
                 windows.map((w) => (
                   <span
                     key={w}
-                    className="inline-flex items-center rounded-md bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-600/20"
+                    className="inline-flex items-center rounded-md bg-brand-subtle px-2 py-0.5 text-xs font-medium text-brand-strong ring-1 ring-inset ring-brand/25"
                   >
                     {w}
                   </span>

--- a/src/components/manager/verify-dialog.tsx
+++ b/src/components/manager/verify-dialog.tsx
@@ -99,7 +99,7 @@ function VerifyForm({
   return (
     <form onSubmit={handleSubmit}>
       <DialogHeader>
-        <DialogTitle>Verify session</DialogTitle>
+        <DialogTitle className="font-display tracking-tight">Verify session</DialogTitle>
         <DialogDescription>
           Confirm the session happened and award volunteer hours to the tutor. This is final —
           corrections are made later as ledger adjustments.
@@ -121,7 +121,7 @@ function VerifyForm({
           </div>
           <div className="flex justify-between gap-3">
             <dt className="text-muted-foreground">Duration</dt>
-            <dd className="text-right font-medium">
+            <dd className="text-right font-medium tabular-nums">
               {session.duration_minutes != null ? `${session.duration_minutes} min` : "—"}
             </dd>
           </div>
@@ -133,7 +133,7 @@ function VerifyForm({
             href={session.recording_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 hover:underline"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-brand hover:underline"
           >
             <ExternalLink className="size-4" aria-hidden="true" />
             Open recording in a new tab

--- a/src/components/member-layout.tsx
+++ b/src/components/member-layout.tsx
@@ -219,14 +219,14 @@ export function MemberLayout({
                   className={cn(
                     "flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors",
                     active
-                      ? "bg-blue-50 text-blue-700"
+                      ? "bg-brand-subtle text-brand-strong"
                       : "text-foreground/80 hover:bg-accent hover:text-foreground",
                   )}
                 >
                   <Icon className="size-4 shrink-0" aria-hidden="true" />
                   <span className="flex-1">{item.label}</span>
                   {item.badge && actionCount > 0 ? (
-                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-semibold text-white">
+                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-brand px-1.5 text-xs font-semibold text-white">
                       {actionCount}
                     </span>
                   ) : null}
@@ -238,7 +238,7 @@ export function MemberLayout({
           {/* Footer identity */}
           <div className="border-t px-3 py-3">
             <div className="flex items-center gap-3 px-2 py-1">
-              <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-blue-100 text-sm font-semibold text-blue-700 uppercase">
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-full bg-brand-subtle text-sm font-semibold text-brand-strong uppercase">
                 {initials || "?"}
               </span>
               <div className="min-w-0 flex-1">

--- a/src/components/page-backdrop.tsx
+++ b/src/components/page-backdrop.tsx
@@ -1,10 +1,10 @@
 import { cn } from "@/lib/utils";
 
 /**
- * The shared gradient-blob backdrop — de-duplicates the gradient layers that the
- * legacy dashboards copy-pasted (§4.10). Renders two soft, blurred, animated
- * blobs behind the page content. Decorative only: fixed, non-interactive, and
- * hidden from assistive tech.
+ * The shared app backdrop. Replaces the legacy animated gradient blobs with a
+ * restrained "Confident SaaS" canvas: the warm off-white base plus a single
+ * faint emerald wash bleeding from the top, and a barely-there hairline grid.
+ * Decorative only: fixed, non-interactive, and hidden from assistive tech.
  *
  * Drop it once near the top of a page/layout; content sits above it via normal
  * stacking (the backdrop is pinned with a negative z-index).
@@ -14,12 +14,14 @@ export function PageBackdrop({ className }: { className?: string }) {
     <div
       aria-hidden="true"
       className={cn(
-        "pointer-events-none fixed inset-0 -z-10 overflow-hidden",
+        "pointer-events-none fixed inset-0 -z-10 overflow-hidden bg-background",
         className,
       )}
     >
-      <div className="absolute -top-24 -left-24 size-[32rem] rounded-full bg-gradient-to-tr from-blue-200 via-indigo-200 to-purple-200 opacity-60 blur-3xl motion-safe:animate-pulse" />
-      <div className="absolute -right-24 -bottom-24 size-[32rem] rounded-full bg-gradient-to-tr from-indigo-200 via-purple-200 to-pink-200 opacity-60 blur-3xl motion-safe:animate-pulse" />
+      {/* Faint emerald light from the top — atmosphere without a color blob. */}
+      <div className="absolute inset-x-0 top-0 h-80 bg-[radial-gradient(80%_100%_at_50%_0%,var(--brand-subtle),transparent_70%)] opacity-70" />
+      {/* Whisper-thin grid for texture; fades out below the fold. */}
+      <div className="absolute inset-0 opacity-60 [mask-image:linear-gradient(to_bottom,black,transparent_55%)] bg-[linear-gradient(to_right,oklch(0.5_0.01_160/0.04)_1px,transparent_1px),linear-gradient(to_bottom,oklch(0.5_0.01_160/0.04)_1px,transparent_1px)] [background-size:44px_44px]" />
     </div>
   );
 }

--- a/src/components/password-input.tsx
+++ b/src/components/password-input.tsx
@@ -37,7 +37,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
             onClick={() => setVisible((v) => !v)}
             aria-label={visible ? "Hide password" : "Show password"}
             aria-pressed={visible}
-            className="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-500 transition-colors hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="absolute inset-y-0 right-0 flex items-center pr-3 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             {visible ? (
               <EyeOff aria-hidden className="h-4 w-4" />
@@ -47,7 +47,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
           </button>
         </div>
         {helper ? (
-          <p id={helperId} className="mt-1.5 text-xs text-gray-500">
+          <p id={helperId} className="mt-1.5 text-xs text-muted-foreground">
             {helper}
           </p>
         ) : null}

--- a/src/components/recording-link-modal.tsx
+++ b/src/components/recording-link-modal.tsx
@@ -106,8 +106,8 @@ function RecordingForm({
   return (
     <>
       <DialogHeader>
-        <DialogTitle className="flex items-center gap-2">
-          <Link2 className="size-5 text-blue-600" aria-hidden="true" />
+        <DialogTitle className="flex items-center gap-2 font-display tracking-tight">
+          <Link2 className="size-5 text-brand" aria-hidden="true" />
           Recording link
         </DialogTitle>
         <DialogDescription>

--- a/src/components/session-row.tsx
+++ b/src/components/session-row.tsx
@@ -37,8 +37,8 @@ function RoleChip({ role }: { role: SessionRole }) {
       className={cn(
         "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ring-1 ring-inset",
         tutoring
-          ? "bg-blue-50 text-blue-700 ring-blue-600/20"
-          : "bg-purple-50 text-purple-700 ring-purple-600/20",
+          ? "bg-brand-subtle text-brand-strong ring-brand/20"
+          : "bg-slate-100 text-slate-600 ring-slate-500/20",
       )}
     >
       {tutoring ? (
@@ -85,7 +85,7 @@ export function SessionRow({
       >
         <RoleChip role={role} />
         <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-foreground">
+          <p className="truncate font-display font-medium tracking-tight text-foreground">
             {session.subject_label}
           </p>
           <p className="truncate text-sm text-muted-foreground">
@@ -158,7 +158,7 @@ export function SessionRow({
               href={session.recording_url}
               target="_blank"
               rel="noreferrer noopener"
-              className="inline-flex items-center gap-1.5 text-blue-600 hover:underline"
+              className="inline-flex items-center gap-1.5 text-brand hover:underline"
             >
               <Video className="size-4" aria-hidden="true" />
               Recording link
@@ -204,7 +204,7 @@ function Detail({
       <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
       <div>
         <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
-        <dd className="text-foreground">{value}</dd>
+        <dd className="text-foreground tabular-nums">{value}</dd>
       </div>
     </div>
   );

--- a/src/components/status-chip.tsx
+++ b/src/components/status-chip.tsx
@@ -7,10 +7,10 @@ export type SessionRole = "requester" | "claimer";
 type ChipTone = "blue" | "amber" | "orange" | "green" | "red" | "neutral";
 
 const TONE_CLASS: Record<ChipTone, string> = {
-  blue: "bg-blue-50 text-blue-700 ring-blue-600/20",
+  blue: "bg-sky-50 text-sky-700 ring-sky-600/20",
   amber: "bg-amber-50 text-amber-700 ring-amber-600/20",
   orange: "bg-orange-50 text-orange-700 ring-orange-600/20",
-  green: "bg-green-50 text-green-700 ring-green-600/20",
+  green: "bg-brand-subtle text-brand-strong ring-brand/25",
   red: "bg-red-50 text-red-700 ring-red-600/20",
   neutral: "bg-muted text-muted-foreground ring-border",
 };

--- a/src/components/two-week-time-grid.tsx
+++ b/src/components/two-week-time-grid.tsx
@@ -141,13 +141,13 @@ export function TwoWeekTimeGrid({ startHour = 7, endHour = 22, stepMinutes = 30,
 
   return (
     <div className={className} onMouseLeave={onMouseUpGrid}>
-      <div className="overflow-auto border rounded">
+      <div className="overflow-auto rounded-xl border bg-card shadow-sm">
         <table className="min-w-full border-collapse select-none">
           <thead>
             <tr>
-              <th className="sticky left-0 bg-white z-10 text-xs text-gray-500 font-medium px-2 py-1 border-b">Time</th>
+              <th className="sticky left-0 bg-card z-10 text-xs text-muted-foreground font-medium px-2 py-1 border-b">Time</th>
               {dateCols.map(date => (
-                <th key={date} className="text-xs text-gray-600 font-medium px-2 py-1 border-b">
+                <th key={date} className="text-xs text-muted-foreground font-medium px-2 py-1 border-b">
                   {new Date(date).toLocaleDateString(undefined, { month: 'short', day: 'numeric', weekday: 'short' })}
                 </th>
               ))}
@@ -156,7 +156,7 @@ export function TwoWeekTimeGrid({ startHour = 7, endHour = 22, stepMinutes = 30,
           <tbody onMouseUp={onMouseUpGrid}>
             {rows.map((t, rowIdx) => (
               <tr key={t}>
-                <td className="sticky left-0 bg-white z-10 text-[11px] text-gray-500 px-2 py-1 border-b">{t}</td>
+                <td className="sticky left-0 bg-card z-10 text-[11px] tabular-nums text-muted-foreground px-2 py-1 border-b">{t}</td>
                 {dateCols.map((date) => {
                   const selected = isSelected(date, rowIdx);
                   const allowedHere = isAllowed(date, rowIdx);
@@ -166,19 +166,12 @@ export function TwoWeekTimeGrid({ startHour = 7, endHour = 22, stepMinutes = 30,
                       onMouseDown={() => onMouseDownCell(date, rowIdx)}
                       onMouseEnter={() => onMouseEnterCell(date, rowIdx)}
                       className={
-                        `h-6 border-b border-l cursor-pointer ` +
+                        `h-6 border-b border-l cursor-pointer transition-colors ` +
                         (selected
-                          ? 'bg-blue-500/80'
+                          ? 'bg-brand/80'
                           : allowedHere
-                            ? 'hover:bg-green-200'
-                            : 'bg-gray-100 cursor-not-allowed')
-                      }
-                      style={
-                        selected
-                          ? {}
-                          : allowedHere
-                            ? { backgroundColor: '#00ff44' }
-                            : {}
+                            ? 'bg-brand-subtle hover:bg-brand/30'
+                            : 'bg-muted cursor-not-allowed')
                       }
                       title={`${date} ${t}`}
                     />
@@ -189,7 +182,7 @@ export function TwoWeekTimeGrid({ startHour = 7, endHour = 22, stepMinutes = 30,
           </tbody>
         </table>
       </div>
-      <div className="mt-2 text-xs text-gray-500">Drag to select time blocks. Click again to remove.</div>
+      <div className="mt-2 text-xs text-muted-foreground">Drag to select time blocks. Click again to remove.</div>
     </div>
   );
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -18,6 +18,14 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
+        // Brand + status semantics (soft fill + ring). Use `brand`/`success`
+        // for verified/approved, `warning` for pending, `destructive` for errors.
+        brand:
+          "bg-brand-subtle text-brand-strong ring-1 ring-inset ring-brand/20 [a&]:hover:bg-brand-subtle/70",
+        success:
+          "bg-brand-subtle text-brand-strong ring-1 ring-inset ring-brand/20",
+        warning:
+          "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-600/20",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,20 +5,21 @@ import { Slot } from "radix-ui"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium whitespace-nowrap transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "inline-flex shrink-0 items-center justify-center gap-2 rounded-md text-sm font-medium tracking-tight whitespace-nowrap transition-all duration-150 outline-none active:scale-[0.985] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90 hover:shadow-sm",
         destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
+          "border bg-card shadow-xs hover:bg-accent hover:text-accent-foreground hover:border-brand/30 dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
-        link: "text-primary underline-offset-4 hover:underline",
+        link: "text-brand underline-offset-4 hover:underline",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm transition-shadow",
         className
       )}
       {...props}
@@ -32,7 +32,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
-      className={cn("leading-none font-semibold", className)}
+      className={cn("font-display leading-none font-semibold tracking-tight", className)}
       {...props}
     />
   )


### PR DESCRIPTION
Replace the generic shadcn default look (blue/indigo/purple gradient blobs, grayscale neutral tokens, Inter) with a cohesive brand identity:

- Theme: warm off-white + ink neutrals, single emerald brand hue, crisp tactile shadows, harmonized chart hues, brand accent token layer.
- Type: Schibsted Grotesk (display) + Hanken Grotesk (body) with tabular numerals; display face on all page/section titles.
- Primitives: tactile Button (press + tracking), display CardTitles, brand/success/warning Badge variants.
- Chrome: all three role shells, status pills, auth shell, and the page backdrop (gradient blobs -> subtle emerald wash + hairline grid).
- Landing page: full rewrite with orchestrated load stagger, emerald hero, tactile cards, and a confident dark "For schools" band.
- Swept every hardcoded blue/indigo/purple/gray to semantic tokens across ~70 files; emerald favicon.

Adds DESIGN_SYSTEM.md as the single design reference. Styling only — no logic, data, or routing changes. tsc + eslint clean.